### PR TITLE
Users api updates

### DIFF
--- a/klabis-api-spec.yaml
+++ b/klabis-api-spec.yaml
@@ -142,10 +142,18 @@ paths:
                 $ref: '#/components/schemas/Member'
         '401':
           description: Unauthorized - not logged in
+
+  /members/{memberId}/changeMemberInfo:
+    parameters:
+      - name: memberId
+        in: path
+        required: true
+        schema:
+          type: integer
     put:
       tags:
         - members
-      summary: "Update member (TBD: move these edits away and/or split them into 2 endpoints?)"
+      summary: "Update member information"
       requestBody:
         required: true
         content:
@@ -157,12 +165,88 @@ paths:
       responses:
         '200':
           description: Club member updated successfully
+        '400':
+          description: Bad request
         '401':
           description: Unauthorized - not logged in
         '403':
           description: Forbidden - User does not have permission to update a member
         '404':
           description: Club member not found
+
+  /members/{memberId}/suspendMembership:
+    parameters:
+      - name: memberId
+        in: path
+        required: true
+        description: ID of the club member whom membership will be suspended
+        schema:
+          type: integer
+    get:
+      tags:
+        - members
+      summary: Retrieve information about member account status for membership suspension
+      description: |
+        Returns information about member account to be suspended. 
+        
+        #### Required authorization
+        requires `members:suspendMembership` grant
+      responses:
+        200:
+          description: details about member account important for membership suspension
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  canSuspend:
+                    type: boolean
+                    description: tells if member account can be suspended
+                  details:
+                    type: object
+                    properties:
+                      finance:
+                        type: object
+                        properties:
+                          status:
+                            type: boolean
+                            description: tells if finance account balance permits membership suspension
+        403:
+          description: Unauthorized - User does not have permission to suspend membership
+        404:
+          description: Club member not found
+    post:
+      tags:
+        - members
+      summary: Suspend membership for a club member
+      description: |
+        Suspends membership for a club member. 
+        
+        If there are some blockers (debt, etc), it responds with HTTP 409 unless `force=true` parameter was used.
+
+        #### Required authorization
+        requires `members:suspendMembership` grant
+      parameters:
+        - name: force
+          in: query
+          description: Forces membership suspension for member even if there are some reasons (like negative finance account balance, etc..) why it would be wise to postpone user membership suspension
+          required: false
+          schema:
+            type: boolean
+            default: false
+      responses:
+        200:
+          description: Membership of club member was suspended successfully
+        403:
+          description: Unauthorized - User does not have permission to suspend membership
+        404:
+          description: Club member not found
+        409:
+          description: It's not possible to suspend membership for club member. See response body for actual reason(s). You may use `force` to override these reasons.
+          content:
+            application/json:
+              type: string
+              example: TO BE DEFINED
 
   /registrationNumber:
     get:
@@ -249,79 +333,6 @@ paths:
           description: Forbidden - User does not have permission to submit registration of new member
         '409':
           description: Conflict - User already exists (usually registration was submitted with existing registration number)
-  /members/{memberId}/suspendMembership:
-    parameters:
-      - name: memberId
-        in: path
-        required: true
-        description: ID of the club member whom membership will be suspended
-        schema:
-          type: integer
-    get:
-      tags:
-        - members
-      summary: Retrieve information about member account status for membership suspension
-      description: |
-        Returns information about member account to be suspended. 
-        
-        #### Required authorization
-        requires `members:suspendMembership` grant
-      responses:
-        200:
-          description: details about member account important for membership suspension
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  canSuspend:
-                    type: boolean
-                    description: tells if member account can be suspended
-                  details:
-                    type: object
-                    properties:
-                      finance:
-                        type: object
-                        properties:
-                          status:
-                            type: boolean
-                            description: tells if finance account balance permits membership suspension
-        403:
-          description: Unauthorized - User does not have permission to suspend membership
-        404:
-          description: Club member not found
-    post:
-      tags:
-        - members
-      summary: Suspend membership for a club member
-      description: |
-        Suspends membership for a club member. 
-        
-        If there are some blockers (debt, etc), it responds with HTTP 409 unless `force=true` parameter was used.
-
-        #### Required authorization
-        requires `members:suspendMembership` grant
-      parameters:
-        - name: force
-          in: query
-          description: Forces membership suspension for member even if there are some reasons (like negative finance account balance, etc..) why it would be wise to postpone user membership suspension
-          required: false
-          schema:
-            type: boolean
-            default: false
-      responses:
-        200:
-          description: Membership of club member was suspended successfully
-        403:
-          description: Unauthorized - User does not have permission to suspend membership
-        404:
-          description: Club member not found
-        409:
-          description: It's not possible to suspend membership for club member. See response body for actual reason(s). You may use `force` to override these reasons.
-          content:
-            application/json:
-              type: string
-              example: TO BE DEFINED
   /cus/exports/members:
     get:
       tags:

--- a/klabis-api-spec.yaml
+++ b/klabis-api-spec.yaml
@@ -256,10 +256,10 @@ components:
       type: string
       pattern: ^[A-Z]{2}$
       description: two letter country code, ISO 3166-1 alpha-2
-    SocialSecurityNumber:
+    BirthCertificateNumber:
       type: string
       pattern: ^[0-9]{6}/[0-9]{3,4}$
-      description: Social security number ("birthday certificate number")
+      description: Birth certificate number for Czech citizens
     RegistrationNumber:
       type: string
       pattern: ^[A-Z]{3}[0-9]{4}$
@@ -317,8 +317,8 @@ components:
           readOnly: true
         registrationNumber:
           $ref: '#/components/schemas/RegistrationNumber'
-        socialSecurityNumber:
-          $ref: '#/components/schemas/SocialSecurityNumber'
+        birthCertificateNumber:
+          $ref: '#/components/schemas/BirthCertificateNumber'
         identityCard:
           $ref: '#/components/schemas/IdentityCard'
         address:
@@ -350,9 +350,7 @@ components:
           type: string
           enum: [male, female]
         licences:
-          type: object
-          items:
-            $ref: '#/components/schemas/Licences'
+          $ref: '#/components/schemas/Licences'
         bankAccount:
           $ref: '#/components/schemas/BankAccountNumber'
         dietaryRestrictions:
@@ -372,7 +370,7 @@ components:
         
         Additional validations: 
         - either contact or guardian needs to be set
-        - when nationality is different than `CZ`, socialSecurityNumber value will be ignored
+        - when nationality is different than `CZ`, `birthCertificateNumber` value will be ignored
       required:
         - firstName
         - lastName
@@ -396,8 +394,8 @@ components:
           type: string
           format: date
           description: Date of birth of the club member
-        socialSecurityNumber:
-          $ref: '#/components/schemas/SocialSecurityNumber'
+        birthCertificateNumber:
+          $ref: '#/components/schemas/BirthCertificateNumber'
         nationality:
           $ref: '#/components/schemas/CountryCode'
         address:
@@ -419,7 +417,7 @@ components:
         Member attributes editable by admin user = user holding grant [TBD]
         
         Additional validations: 
-        - when `CZ` is selected as nationality, then `socialSecurityNumber` is required value
+        - when `CZ` is selected as nationality, then `birthCertificateNumber` is required value
       required:
         - firstName
         - lastName
@@ -440,8 +438,8 @@ components:
           format: date
           description: |-
             Date of birth of the club member
-        socialSecurityNumber:
-          $ref: '#/components/schemas/SocialSecurityNumber'
+        birthCertificateNumber:
+          $ref: '#/components/schemas/BirthCertificateNumber'
         nationality:
           $ref: '#/components/schemas/CountryCode'
         gender:
@@ -503,46 +501,55 @@ components:
           description: Note about the guardian (matka, otec)
     BankAccountNumber:
       type: string
+      pattern: ^[A-Z]{2}[0-9]+$
       description: |-
         Bank account number of the club member IBAN
     OBLicence:
-      type: string
-      enum: [ E, R, A, B, C ]
-      description: License number of the club member
+      type: object
+      required:
+        - licence
+      properties:
+        licence:
+          type: string
+          enum: [ E, R, A, B, C ]
+          description: License number of the club member
     RefereeLicence:
-      type: string
-      enum: [ R1, R2, R3 ]
-      description: referee license number of the club member
+      type: object
+      required:
+        - licence
+        - expiryDate
+      properties:
+        licence:
+          type: string
+          enum: [ R1, R2, R3 ]
+          description: referee license number of the club member
+        expiryDate:
+          type: string
+          format: date
+          description: Expiry date of the license
     TrainerLicence:
-      type: string
-      enum: [ T1, T2, T3 ]
-      description: trainer license number of the club member
+      type: object
+      required:
+        - licence
+        - expiryDate
+      properties:
+        licence:
+          type: string
+          enum: [ T1, T2, T3 ]
+          description: trainer license number of the club member
+        expiryDate:
+          type: string
+          format: date
+          description: Expiry date of the license
     Licences:
       type: object
       properties:
         ob:
-          type: object
-          properties:
-            licence:
-              $ref: '#/components/schemas/OBLicence'
+          $ref: '#/components/schemas/OBLicence'
         referee:
-          type: object
-          properties:
-            licence:
-              $ref: '#/components/schemas/OBLicence'
-            expiryDate:
-              type: string
-              format: date
-              description: Expiry date of the license, YYYY-MM-DD
+          $ref: '#/components/schemas/RefereeLicence'
         trainer:
-          type: object
-          properties:
-            licence:
-              $ref: '#/components/schemas/OBLicence'
-            expiryDate:
-              type: string
-              format: date
-              description: Expiry date of the license, YYYY-MM-DD
+          $ref: '#/components/schemas/TrainerLicence'
     DeleteCheck:
       type: object
       properties:

--- a/klabis-api-spec.yaml
+++ b/klabis-api-spec.yaml
@@ -97,13 +97,13 @@ paths:
               - full
               - compact
             default: compact
-        - name: archived
+        - name: suspended
           in: query
           required: false
           description: |
             | value | effect |
             | --- | --- |
-            | `true` | returns both active and archived members | 
+            | `true` | returns both active and suspended members | 
             | `false` | return only active members |
           schema:
             type: boolean
@@ -238,41 +238,41 @@ paths:
           description: Forbidden - User does not have permission to submit registration of new member
         '409':
           description: Conflict - User already exists (usually registration was submitted with existing registration number)
-  /memberDeregistrations/{memberId}:
-    put:
+  /members/{memberId}/suspendMembership:
+    post:
       tags:
         - members
-      summary: Deregister a club member
+      summary: Suspend membership for a club member
       description: |
-        Deregisters a club member. 
+        Suspends membership for a club member. 
         
         If there are some blockers (debt, etc), it responds with HTTP 409 unless `force=true` parameter was used.
 
         #### Required authorization
-        requires `members:deregister` grant
+        requires `members:suspendMembership` grant
       parameters:
         - name: memberId
           in: path
           required: true
-          description: ID of the club member who will be deregistered from club
+          description: ID of the club member whom membership will be suspended
           schema:
             type: integer
         - name: force
           in: query
-          description: Forces user deregistration even if there are some reasons (like negative finance account balance, etc..) why it would be wise to postpone user deregistration
+          description: Forces membership suspension for member even if there are some reasons (like negative finance account balance, etc..) why it would be wise to postpone user membership suspension
           required: false
           schema:
             type: boolean
             default: false
       responses:
         '200':
-          description: Club member deregistration processed successfully
+          description: Membership of club member was suspended successfully
         '403':
-          description: Unauthorized - User does not have permission to archive a member
+          description: Unauthorized - User does not have permission to suspend membership
         '404':
           description: Club member not found
         '409':
-          description: It's not possible to deregister club member. See response body for actual reason(s). You may use `force` to override these reasons.
+          description: It's not possible to suspend membership for club member. See response body for actual reason(s). You may use `force` to override these reasons.
           content:
             application/json:
               type: string
@@ -646,11 +646,11 @@ components:
         | --- | --- |
         | `members:register` | can create new members |
         | `members:edit` | can edit selected attributes for all existing members |
-        | `members:deregister` | can deregister club members |
+        | `members:suspendMembership` | can suspend membership for club members |
       enum:
         - members:register
         - members:edit
-        - members:deregister
+        - members:suspendMembership
     MemberSpecificGrants:
       type: string
       description: |

--- a/klabis-api-spec.yaml
+++ b/klabis-api-spec.yaml
@@ -10,9 +10,16 @@ info:
   version: 0.1.12
 servers:
   - url: https://api.klabis.otakar.io
+  - url: https://klabis-auth.polach.cloud
 tags:
   - name: users
-  - name: auth
+    description: Members list
+  - name: security
+    description: API used to control authentization and authorization
+  - name: oris
+    description: Integration endpoints with ORIS - https://oris.orientacnisporty.cz/
+  - name: cus
+    description: Integration endpoints with CUS - https://www.cuscz.cz/
 security:
   - klabisAuth:
       - openid
@@ -20,10 +27,10 @@ paths:
   /password:
     put:
       tags:
-        - auth
+        - security
       summary: "[WIP] - Set a new password"
       description: >
-        Sets a new password for the user
+        Sets a new password for currently logged in user
       requestBody:
         required: true
         content:
@@ -83,7 +90,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateUserForm'
+              $ref: '#/components/schemas/FormCreateUser'
       responses:
         '201':
           description: New club member created successfully
@@ -100,7 +107,6 @@ paths:
       tags:
         - users
       summary: Get user by ID
-      operationId: getUserById
       description: Returns a user
       parameters:
         - name: userId
@@ -133,7 +139,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateUserForm'
+              oneOf:
+                - $ref: '#/components/schemas/FormUpdateMyUserData'
+                - $ref: '#/components/schemas/FormUpdateUserByAdmin'
       responses:
         '200':
           description: Club member updated successfully
@@ -217,10 +225,10 @@ paths:
                 description: A free registration ID
         '401':
           description: Unauthorized - not logged in
-  /users/exports/cus:
+  /cus/exports/members:
     get:
       tags:
-        - users
+        - cus
       summary: "[WIP] - export users in CUS format"
       responses:
         '200':
@@ -229,12 +237,12 @@ paths:
           description: Unauthorized - not logged in
         '403':
           description: Forbidden - User does not have permission to delete a member
-  /users/oris:
+  /oris/users:
     get:
       tags:
-        - users
+        - oris
       summary: "[WIP] - get info about existing user from oris"
-      description: used when preexisting user is added to the system
+      description: used when looking for preexisting user is added to the system
       responses:
         '200':
           description: user info
@@ -244,14 +252,24 @@ paths:
           description: Forbidden - User does not have permission for this
 components:
   schemas:
+    CountryCode:
+      type: string
+      pattern: ^[A-Z]{2}$
+      description: two letter country code, ISO 3166-1 alpha-2
     SocialSecurityNumber:
       type: string
-      pattern: ^[0..9]{6}/[0..9]{4}$
+      pattern: ^[0-9]{6}/[0-9]{3,4}$
       description: Social security number ("birthday certificate number")
     RegistrationNumber:
       type: string
-      pattern: ^[A..Z]{3}[0..9]{4}$
+      pattern: ^[A-Z]{3}[0-9]{4}$
       description: ORIS registration number
+    DrivingLicence:
+      type: string
+      enum: [ B, BE, C, D, None ]
+    SICard:
+      type: number
+      description: SI chip used by member
     Contact:
       type: object
       description: At least one of email or phone value is required
@@ -279,8 +297,7 @@ components:
           type: string
           description: Postal or ZIP code
         country:
-          type: string
-          description: two letter country code, ISO 3166-1 alpha-2
+          $ref: '#/components/schemas/CountryCode'
     IdentityCard:
       type: object
       properties:
@@ -328,8 +345,7 @@ components:
           type: number
           description: Chip number assigned to the club member
         nationality:
-          type: string
-          description: two letter country code, ISO 3166-1 alpha-2
+          $ref: '#/components/schemas/CountryCode'
         sex:
           type: string
           enum: [male, female]
@@ -338,7 +354,7 @@ components:
           items:
             $ref: '#/components/schemas/Licences'
         bankAccount:
-          $ref: '#/components/schemas/BankAccount'
+          $ref: '#/components/schemas/BankAccountNumber'
         dietaryRestrictions:
           type: string
           description: Dietary restrictions of the club member
@@ -349,15 +365,11 @@ components:
         medicCourse:
           type: boolean
           description: Whether the club member has completed the medic course
-    DrivingLicence:
-      type: string
-      enum: [ B, BE, C, D, None ]
-    BankAccount:
-      type: string
-      description: Bank account number of the club member IBAN
-    CreateUserForm:
+    FormCreateUser:
       type: object
       description: |-
+        Data required to create new member.  
+        
         Additional validations: 
         - either contact or guardian needs to be set
         - when nationality is different than `CZ`, socialSecurityNumber value will be ignored
@@ -387,8 +399,7 @@ components:
         socialSecurityNumber:
           $ref: '#/components/schemas/SocialSecurityNumber'
         nationality:
-          type: string
-          description: two letter country code, ISO 3166-1 alpha-2
+          $ref: '#/components/schemas/CountryCode'
         address:
           $ref: '#/components/schemas/Address'
         contact:
@@ -398,94 +409,80 @@ components:
           items:
             $ref: '#/components/schemas/LegalGuardian'
         siCard:
-          properties:
-            number:
-              type: number
-              description: Chip number assigned to the club member
+          $ref: '#/components/schemas/SICard'
         dietaryRestrictions:
           type: string
           description: Dietary restrictions of the club member
-    UpdateUserForm:
+    FormUpdateUserByAdmin:
       type: object
+      description: |-
+        Member attributes editable by admin user = user holding grant [TBD]
+        
+        Additional validations: 
+        - when `CZ` is selected as nationality, then `socialSecurityNumber` is required value
+      required:
+        - firstName
+        - lastName
+        - dateOfBirth
+        - nationality
+        - gender
       properties:
         firstName:
           type: string
           description: |-
-            [Admin] First name of the club member"
+            First name of the club member
         lastName:
           type: string
           description: |-
-            [Admin] Last name of the club member
+            Last name of the club member
         dateOfBirth:
           type: string
           format: date
           description: |-
-            [Admin] Date of birth of the club member
+            Date of birth of the club member
         socialSecurityNumber:
-          type: string
-          description: |-
-            [Admin]
-        identityCard:
-          allOf:
-            - $ref: '#/components/schemas/IdentityCard'
-            - description: |-
-                [User]
+          $ref: '#/components/schemas/SocialSecurityNumber'
         nationality:
-          type: string
-          description: |-
-            [Admin] two letter country code, ISO 3166-1 alpha-2
-        address:
-          allOf:
-            - $ref: '#/components/schemas/Address'
-            - description: |-
-                [User]
-        contact:
-          type: object
-          description: |-
-            [User]
-          items:
-            $ref: '#/components/schemas/Contact'
-        guardians:
-          type: array
-          description: |-
-            [User]
-          items:
-            $ref: '#/components/schemas/LegalGuardian'
-        siCards:
-          type: array
-          description: |-
-            [User]
-          items:
-            type: object
-            properties:
-              number:
-                type: number
-                description: Chip number assigned to the club member
-              isPrimary:
-                type: boolean
-                description: Whether the contact is primary or not
+          $ref: '#/components/schemas/CountryCode'
         gender:
           type: string
-          description: |-
-            [Admin]
           enum: [ male, female ]
+    FormUpdateMyUserData:
+      description: |-
+        Member attributes which can be updated by member himself (member can update some own attributes)  
+        
+        Additional validations:
+        - either contact or at least 1 guardian needs to be entered
+      required:
+        - identityCard
+        - address
+      properties:
+        identityCard:
+          $ref: '#/components/schemas/IdentityCard'
+        address:
+          $ref: '#/components/schemas/Address'
+        contact:
+          $ref: '#/components/schemas/Contact'
+        guardians:
+          type: array
+          items:
+            $ref: '#/components/schemas/LegalGuardian'
+        siCard:
+          $ref: '#/components/schemas/SICard'
         bankAccount:
-          type: string
-          description: |-
-            [User] Bank account number of the club member IBAN
+          $ref: '#/components/schemas/BankAccountNumber'
         dietaryRestrictions:
           type: string
           description: |-
-            [User] Dietary restrictions of the club member
+            Dietary restrictions of the club member
         drivingLicence:
-          type: string
-          description: |-
-            [User]
-          enum: [B, BE, C, D, None]
+          type: array
+          items:
+            $ref: '#/components/schemas/DrivingLicence'
         medicCourse:
           type: boolean
           description: |-
-            [User] Whether the club member has completed the medic course
+            Whether the club member has completed the medic course
     LegalGuardian:
       type: object
       required:
@@ -504,6 +501,10 @@ components:
         note:
           type: string
           description: Note about the guardian (matka, otec)
+    BankAccountNumber:
+      type: string
+      description: |-
+        Bank account number of the club member IBAN
     OBLicence:
       type: string
       enum: [ E, R, A, B, C ]

--- a/klabis-api-spec.yaml
+++ b/klabis-api-spec.yaml
@@ -120,7 +120,7 @@ paths:
                     - $ref: '#/components/schemas/Member'
                     - $ref: '#/components/schemas/MemberViewCompact'
         '401':
-            description: Unauthorized - not logged in
+          $ref: '#/components/responses/401'
   /members/{memberId}:
     parameters:
       - name: memberId
@@ -141,7 +141,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Member'
         '401':
-          description: Unauthorized - not logged in
+          $ref: '#/components/responses/401'
 
   /members/{memberId}/editMemberInfoForm:
     parameters:
@@ -166,12 +166,14 @@ paths:
         '200':
           description: Club member updated successfully
         '400':
-          description: Bad request
+          $ref: '#/components/responses/400'
         '401':
-          description: Unauthorized - not logged in
+          $ref: '#/components/responses/401'
         '403':
+          $ref: '#/components/responses/403'
           description: Forbidden - User does not have permission to update a member
         '404':
+          $ref: '#/components/responses/401'
           description: Club member not found
 
   /members/{memberId}/suspendMembershipForm:
@@ -192,7 +194,7 @@ paths:
         #### Required authorization
         requires `members:suspendMembership` grant
       responses:
-        200:
+        '200':
           description: details about member account important for membership suspension
           content:
             application/json:
@@ -207,9 +209,10 @@ paths:
                     description: tells if member account can be suspended
                   details:
                     $ref: '#/components/schemas/SuspendMembershipBlockers'
-        403:
-          description: Unauthorized - User does not have permission to suspend membership
-        404:
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/401'
           description: Club member not found
     post:
       tags:
@@ -218,7 +221,7 @@ paths:
       description: |
         Suspends membership for a club member. 
         
-        If there are some blockers (debt, etc), it responds with HTTP 409 unless `force=true` parameter was used.
+        If there are some blockers (debt, etc), it responds with HTTP '409' unless `force=true` parameter was used.
 
         #### Required authorization
         requires `members:suspendMembership` grant
@@ -231,23 +234,31 @@ paths:
             type: boolean
             default: false
       responses:
-        200:
+        '200':
           description: Membership of club member was suspended successfully
-        403:
-          description: Unauthorized - User does not have permission to suspend membership
-        404:
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+          description: Forbidden - User does not have permission to update a member
+        '404':
+          $ref: '#/components/responses/401'
           description: Club member not found
-        409:
+        '409':
           description: It's not possible to suspend membership for club member. See response body for actual reason(s). You may use `force` to override these reasons.
           content:
-            application/json:
+            application/problem+json:
               schema:
-                type: object
-                required:
-                  - blockers
-                properties:
-                  blockers:
-                    $ref: '#/components/schemas/SuspendMembershipBlockers'
+                allOf:
+                  - $ref: '#/components/schemas/RFC7807ErrorResponse'
+                  - type: object
+                    required:
+                      - blockers
+                    properties:
+                      blockers:
+                        $ref: '#/components/schemas/SuspendMembershipBlockers'
   /registrationNumber:
     get:
       tags:
@@ -267,7 +278,7 @@ paths:
           schema:
             $ref: '#/components/schemas/Sex'
       responses:
-        200:
+        '200':
           description: Recommended (available) registration number for new member registration
           content:
             application/json:
@@ -278,8 +289,10 @@ paths:
                 properties:
                   availableRegistrationNumber:
                     $ref: '#/components/schemas/RegistrationNumber'
-        400:
-          description: Bad request - Invalid data
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
 
   /oris/userInfo/{orisId}:
     get:
@@ -297,16 +310,20 @@ paths:
           in: path
           description: ORIS ID of user to retrieve ORIS data about
       responses:
-        200:
+        '200':
           description: Available information about user read from ORIS
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ORISUserInfo'
-        400:
-          description: Bad request - Invalid data
-        403:
-          description: Forbidden - User does not have permission to submit registration of new member
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/401'
 
   /memberRegistrations:
     post:
@@ -328,11 +345,24 @@ paths:
         '201':
           description: Registration was processed successfully
         '400':
-          description: Bad request - Invalid data
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
         '403':
-          description: Forbidden - User does not have permission to submit registration of new member
+          $ref: '#/components/responses/403'
+          description: Forbidden - User does not have permission for this action
         '409':
-          description: Conflict - User already exists (usually registration was submitted with existing registration number)
+          description: Conflict - Member already exists (usually registration was submitted with existing registration number)
+          content:
+            application/problem+json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/RFC7807ErrorResponse'
+                  - type: object
+                    properties:
+                      existingUserId:
+                        type: uuid
+                        description: ID of conflicting member
   /cus/exports/members:
     get:
       tags:
@@ -342,9 +372,9 @@ paths:
         '200':
           description: A list of differences
         '401':
-          description: Unauthorized - not logged in
+          $ref: '#/components/responses/401'
         '403':
-          description: Forbidden - User does not have permission to delete a member
+          $ref: '#/components/responses/403'
 components:
   schemas:
     CountryCode:
@@ -758,6 +788,72 @@ components:
         - members#canDisplayMemberPersonalContact
         - members#canDisplayMemberLegalGuardianContact
         - members#canDisplayMemberAddress
+    RFC7807ErrorResponse:
+      type: object
+      required:
+        - title
+        - status
+        - detail
+        - instance
+      properties:
+        title:
+          type: string
+          description: Description of the error status
+        status:
+          type: integer
+          description: error status value
+        detail:
+          type: string
+          description: User friendly description of the error
+        instance:
+          type: string
+          description: URI of the resource which has thrown the error
+        type:
+          type: string
+  responses:
+    '400':
+      description: Invalid user input
+      content:
+        application/problem+json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/RFC7807ErrorResponse'
+              - type: object
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        fieldName:
+                          type: string
+                        errorMessage:
+                          type: string
+    '401':
+      description: Missing required user authentication or authentication failed
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/RFC7807ErrorResponse'
+    '403':
+      description: User is not allowed to perform requested operation
+      content:
+        application/problem+json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/RFC7807ErrorResponse'
+              - type: object
+                properties:
+                  missingGrant:
+                    anyOf:
+                      - $ref: "#/components/schemas/GlobalGrants"
+                      - $ref: "#/components/schemas/MemberSpecificGrants"
+    '404':
+      description: Requested resource wasn't found
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/RFC7807ErrorResponse'
   securitySchemes:
     klabis:
       type: openIdConnect

--- a/klabis-api-spec.yaml
+++ b/klabis-api-spec.yaml
@@ -54,7 +54,7 @@ tags:
   - name: WIP
     description: "[odkladiste pro 'work-in-progress' endpointy]"
 paths:
-  /password:
+  /me/password:
     put:
       tags:
         - WIP
@@ -122,18 +122,17 @@ paths:
         '401':
             description: Unauthorized - not logged in
   /members/{memberId}:
+    parameters:
+      - name: memberId
+        in: path
+        required: true
+        schema:
+          type: integer
     get:
       tags:
         - members
       summary: Get member by ID
       description: Returns a member
-      parameters:
-        - name: memberId
-          in: path
-          required: true
-          description: ID of the club member to get
-          schema:
-            type: integer
       responses:
         '200':
           description: A single member
@@ -147,12 +146,6 @@ paths:
       tags:
         - members
       summary: "Update member (TBD: move these edits away and/or split them into 2 endpoints?)"
-      parameters:
-        - name: memberId
-          in: path
-          required: true
-          schema:
-            type: integer
       requestBody:
         required: true
         content:
@@ -239,6 +232,46 @@ paths:
         '409':
           description: Conflict - User already exists (usually registration was submitted with existing registration number)
   /members/{memberId}/suspendMembership:
+    parameters:
+      - name: memberId
+        in: path
+        required: true
+        description: ID of the club member whom membership will be suspended
+        schema:
+          type: integer
+    get:
+      tags:
+        - members
+      summary: Retrieve information about member account status for membership suspension
+      description: |
+        Returns information about member account to be suspended. 
+        
+        #### Required authorization
+        requires `members:suspendMembership` grant
+      responses:
+        200:
+          description: details about member account important for membership suspension
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  canSuspend:
+                    type: boolean
+                    description: tells if member account can be suspended
+                  details:
+                    type: object
+                    properties:
+                      finance:
+                        type: object
+                        properties:
+                          status:
+                            type: boolean
+                            description: tells if finance account balance permits membership suspension
+        403:
+          description: Unauthorized - User does not have permission to suspend membership
+        404:
+          description: Club member not found
     post:
       tags:
         - members
@@ -251,12 +284,6 @@ paths:
         #### Required authorization
         requires `members:suspendMembership` grant
       parameters:
-        - name: memberId
-          in: path
-          required: true
-          description: ID of the club member whom membership will be suspended
-          schema:
-            type: integer
         - name: force
           in: query
           description: Forces membership suspension for member even if there are some reasons (like negative finance account balance, etc..) why it would be wise to postpone user membership suspension
@@ -265,13 +292,13 @@ paths:
             type: boolean
             default: false
       responses:
-        '200':
+        200:
           description: Membership of club member was suspended successfully
-        '403':
+        403:
           description: Unauthorized - User does not have permission to suspend membership
-        '404':
+        404:
           description: Club member not found
-        '409':
+        409:
           description: It's not possible to suspend membership for club member. See response body for actual reason(s). You may use `force` to override these reasons.
           content:
             application/json:

--- a/klabis-api-spec.yaml
+++ b/klabis-api-spec.yaml
@@ -820,7 +820,7 @@ components:
               - $ref: '#/components/schemas/RFC7807ErrorResponse'
               - type: object
                 properties:
-                  errors:
+                  validationErrors:
                     type: array
                     items:
                       type: object

--- a/klabis-api-spec.yaml
+++ b/klabis-api-spec.yaml
@@ -57,16 +57,28 @@ paths:
       parameters:
         - name: view
           in: query
+          required: false
+          description: |
+            Defines set of returned data
+            - full: all member data what are displayable to logged in user are returned
+            - compact: `id`, `firstName`, `lastName`, 'registrationNumber`
           schema:
             type: string
             enum:
               - full
               - compact
             default: compact
-            description: |-
-              Defines set of returned data
-              - full: all user data what are displayable to authenticated user are returned
-              - compact: `id`, `firstName`, `lastName`, 'registrationNumber`
+        - name: archived
+          in: query
+          required: false
+          description: |
+            | value | effect |
+            | --- | --- |
+            | `true` | returns both active and archived members | 
+            | `false` | return only active members |
+          schema:
+            type: boolean
+            default: false
       responses:
         '200':
           description: A list of club users

--- a/klabis-api-spec.yaml
+++ b/klabis-api-spec.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.0
+openapi: 3.1.0
 info:
   title: Klabis - OpenAPI 3.1
   description: Klabis API docs
@@ -9,13 +9,13 @@ info:
     url: https://opensource.org/licenses/MIT
   version: 0.1.12
 servers:
-  - url: https://api.klabis.otakar.io
   - url: https://klabis-auth.polach.cloud
+  - url: https://api.klabis.otakar.io
 tags:
   - name: users
     description: Members list
   - name: security
-    description: API used to control authentization and authorization
+    description: API used to control authentication and authorization
   - name: oris
     description: Integration endpoints with ORIS - https://oris.orientacnisporty.cz/
   - name: cus
@@ -60,13 +60,13 @@ paths:
           schema:
             type: string
             enum:
-              - complete
+              - full
               - compact
             default: compact
             description: |-
               Defines set of returned data
-              - complete: all user data what are displayable to authenticated user are returned
-              - compact: `firstName`, `lastName`, 'registrationNumber`
+              - full: all user data what are displayable to authenticated user are returned
+              - compact: `id`, `firstName`, `lastName`, 'registrationNumber`
       responses:
         '200':
           description: A list of club users
@@ -75,7 +75,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/User'
+                  oneOf:
+                    - $ref: '#/components/schemas/User'
+                    - $ref: '#/components/schemas/UserViewCompact'
         '401':
             description: Unauthorized - not logged in
 
@@ -311,61 +313,76 @@ components:
           type: string
           format: date
           description: Expiry date of the ID card, YYYY-MM-DD
-    User:
+    UserViewCompact:
       type: object
+      required:
+        - id
+        - firstName
+        - lastName
+        - registrationNumber
       properties:
         id:
           type: integer
           description: Unique identifier for the club member
           readOnly: true
-        registrationNumber:
-          $ref: '#/components/schemas/RegistrationNumber'
-        birthCertificateNumber:
-          $ref: '#/components/schemas/BirthCertificateNumber'
-        identityCard:
-          $ref: '#/components/schemas/IdentityCard'
-        address:
-          $ref: '#/components/schemas/Address'
         firstName:
           type: string
           description: First name of the club member
         lastName:
           type: string
           description: Last name of the club member
-        dateOfBirth:
-          type: string
-          format: date
-          description: Date of birth of the club member
-        contact:
-          type: object
-          items:
-            $ref: '#/components/schemas/Contact'
-        legalGuardians:
-          type: array
-          items:
-            $ref: '#/components/schemas/LegalGuardian'
-        siCard:
-          type: number
-          description: Chip number assigned to the club member
-        nationality:
-          $ref: '#/components/schemas/CountryCode'
-        sex:
-          type: string
-          enum: [male, female]
-        licences:
-          $ref: '#/components/schemas/Licences'
-        bankAccount:
-          $ref: '#/components/schemas/BankAccountNumber'
-        dietaryRestrictions:
-          type: string
-          description: Dietary restrictions of the club member
-        drivingLicence:
-          type: array
-          items:
-            $ref: '#/components/schemas/DrivingLicence'
-        medicCourse:
-          type: boolean
-          description: Whether the club member has completed the medic course
+        registrationNumber:
+          $ref: '#/components/schemas/RegistrationNumber'
+    User:
+      allOf:
+        - $ref: '#/components/schemas/UserViewCompact'
+        - type: object
+          required:
+            - id
+          properties:
+            id:
+              type: integer
+              description: Unique identifier for the club member
+            birthCertificateNumber:
+              $ref: '#/components/schemas/BirthCertificateNumber'
+            identityCard:
+              $ref: '#/components/schemas/IdentityCard'
+            address:
+              $ref: '#/components/schemas/Address'
+            dateOfBirth:
+              type: string
+              format: date
+              description: Date of birth of the club member
+            contact:
+              type: object
+              items:
+                $ref: '#/components/schemas/Contact'
+            legalGuardians:
+              type: array
+              items:
+                $ref: '#/components/schemas/LegalGuardian'
+            siCard:
+              type: number
+              description: Chip number assigned to the club member
+            nationality:
+              $ref: '#/components/schemas/CountryCode'
+            sex:
+              type: string
+              enum: [male, female]
+            licences:
+              $ref: '#/components/schemas/Licences'
+            bankAccount:
+              $ref: '#/components/schemas/BankAccountNumber'
+            dietaryRestrictions:
+              type: string
+              description: Dietary restrictions of the club member
+            drivingLicence:
+              type: array
+              items:
+                $ref: '#/components/schemas/DrivingLicence'
+            medicCourse:
+              type: boolean
+              description: Whether the club member has completed the medic course
     FormCreateUser:
       type: object
       description: |-

--- a/klabis-api-spec.yaml
+++ b/klabis-api-spec.yaml
@@ -362,6 +362,8 @@ components:
           format: date
           description: Expiry date of the ID card, YYYY-MM-DD
     MemberViewCompact:
+      description: |
+        'compact' view of Member
       type: object
       required:
         - id
@@ -436,6 +438,8 @@ components:
             medicCourse:
               type: boolean
               description: Whether the club member has completed the medic course
+        - description: Member attributes
+
     MemberRegistrationForm:
       type: object
       description: |-

--- a/klabis-api-spec.yaml
+++ b/klabis-api-spec.yaml
@@ -13,57 +13,17 @@ servers:
 tags:
   - name: users
   - name: auth
+security:
+  - klabisAuth:
+      - openid
 paths:
-  /login:
-    post:
-      tags:
-        - auth
-      summary: Login to the application
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                username:
-                  type: string
-                  description: Registration number or email
-                password:
-                  type: string
-                  description: The password for login
-      responses:
-        '200':
-          description: User logged in successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  token:
-                    type: string
-                    description: OIDC obtained token
-        '401':
-          description: Unauthorized - Invalid username or password
-  /logout:
-    post:
-      tags:
-        - auth
-      summary: Logout from the application
-      responses:
-        '200':
-          description: User logged out successfully
-        '401':
-          description: Unauthorized - User is not logged in
   /password:
     put:
       tags:
         - auth
-      summary: Set a new password
+      summary: "[WIP] - Set a new password"
       description: >
         Sets a new password for the user
-      security:
-        - BearerAuth: []
       requestBody:
         required: true
         content:
@@ -87,6 +47,19 @@ paths:
         - users
       summary: List all club users
       description: Returns a list of all club users
+      parameters:
+        - name: view
+          in: query
+          schema:
+            type: string
+            enum:
+              - complete
+              - compact
+            default: compact
+            description: |-
+              Defines set of returned data
+              - complete: all user data what are displayable to authenticated user are returned
+              - compact: `firstName`, `lastName`, 'registrationNumber`
       responses:
         '200':
           description: A list of club users
@@ -110,7 +83,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateUser'
+              $ref: '#/components/schemas/CreateUserForm'
       responses:
         '201':
           description: New club member created successfully
@@ -127,6 +100,7 @@ paths:
       tags:
         - users
       summary: Get user by ID
+      operationId: getUserById
       description: Returns a user
       parameters:
         - name: userId
@@ -159,7 +133,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateUser'
+              $ref: '#/components/schemas/UpdateUserForm'
       responses:
         '200':
           description: Club member updated successfully
@@ -169,7 +143,8 @@ paths:
           description: Forbidden - User does not have permission to update a member
         '404':
           description: Club member not found
-    delete:
+  /users/{userId}/archive:
+    put:
       tags:
         - users
       summary: Archive member
@@ -177,21 +152,21 @@ paths:
         - name: userId
           in: path
           required: true
-          description: ID of the club member to delete
+          description: ID of the club member to archive
           schema:
             type: integer
       responses:
         '200':
           description: Club member archived successfully
-        '401':
-          description: Unauthorized - User does not have permission to delete a member
+        '403':
+          description: Unauthorized - User does not have permission to archive a member
         '404':
           description: Club member not found
   /users/{userId}/delete-check:
     get:
       tags:
         - users
-      summary: Check if user can be deleted
+      summary: "[WIP] - Check if user can be deleted"
       description: >
             returns reason why user can't be deleted
       parameters:
@@ -218,7 +193,7 @@ paths:
     get:
       tags:
         - users
-      summary: Get a free registration ID
+      summary: "[WIP] - Get a free registration ID"
       description: >
         Returns a free registration ID that can be used to register a new club member.
       requestBody:
@@ -246,7 +221,7 @@ paths:
     get:
       tags:
         - users
-      summary: export users in CUS format
+      summary: "[WIP] - export users in CUS format"
       responses:
         '200':
           description: A list of differences
@@ -258,24 +233,29 @@ paths:
     get:
       tags:
         - users
-      summary: get info about existing user from oris
+      summary: "[WIP] - get info about existing user from oris"
       description: used when preexisting user is added to the system
       responses:
         '200':
           description: user info
-          # content:
         '401':
           description: Unauthorized - not logged in
         '403':
           description: Forbidden - User does not have permission for this
 components:
   schemas:
+    SocialSecurityNumber:
+      type: string
+      pattern: ^[0..9]{6}/[0..9]{4}$
+      description: Social security number ("birthday certificate number")
+    RegistrationNumber:
+      type: string
+      pattern: ^[A..Z]{3}[0..9]{4}$
+      description: ORIS registration number
     Contact:
       type: object
+      description: At least one of email or phone value is required
       properties:
-        isPrimary:
-          type: boolean
-          description: Whether the contact is primary or not
         email:
           type: string
           format: email
@@ -317,9 +297,15 @@ components:
         id:
           type: integer
           description: Unique identifier for the club member
+          readOnly: true
         registrationNumber:
-          type: string
-          description: Registration number of the club member
+          $ref: '#/components/schemas/RegistrationNumber'
+        socialSecurityNumber:
+          $ref: '#/components/schemas/SocialSecurityNumber'
+        identityCard:
+          $ref: '#/components/schemas/IdentityCard'
+        address:
+          $ref: '#/components/schemas/Address'
         firstName:
           type: string
           description: First name of the club member
@@ -330,35 +316,21 @@ components:
           type: string
           format: date
           description: Date of birth of the club member
-        birthCertificateNumber:
-          type: string
-        identityCard:
-          $ref: '#/components/schemas/IdentityCard'
-        nationality:
-          type: string
-          description: two letter country code, ISO 3166-1 alpha-2
-        address:
-          $ref: '#/components/schemas/Address'
         contact:
           type: object
           items:
             $ref: '#/components/schemas/Contact'
-        guardians:
+        legalGuardians:
           type: array
           items:
-            $ref: '#/components/schemas/Guardian'
-        siCards:
-          type: array
-          items:
-            type: object
-            properties:
-              number:
-                type: number
-                description: Chip number assigned to the club member
-              isPrimary:
-                type: boolean
-                description: Whether the contact is primary or not
-        gender:
+            $ref: '#/components/schemas/LegalGuardian'
+        siCard:
+          type: number
+          description: Chip number assigned to the club member
+        nationality:
+          type: string
+          description: two letter country code, ISO 3166-1 alpha-2
+        sex:
           type: string
           enum: [male, female]
         licences:
@@ -366,19 +338,36 @@ components:
           items:
             $ref: '#/components/schemas/Licences'
         bankAccount:
-          type: string
-          description: Bank account number of the club member IBAN
+          $ref: '#/components/schemas/BankAccount'
         dietaryRestrictions:
           type: string
           description: Dietary restrictions of the club member
         drivingLicence:
-          type: string
-          enum: [B, BE, C, D, None]
+          type: array
+          items:
+            $ref: '#/components/schemas/DrivingLicence'
         medicCourse:
           type: boolean
           description: Whether the club member has completed the medic course
-    CreateUser:
+    DrivingLicence:
+      type: string
+      enum: [ B, BE, C, D, None ]
+    BankAccount:
+      type: string
+      description: Bank account number of the club member IBAN
+    CreateUserForm:
       type: object
+      description: |-
+        Additional validations: 
+        - either contact or guardian needs to be set
+        - when nationality is different than `CZ`, socialSecurityNumber value will be ignored
+      required:
+        - firstName
+        - lastName
+        - gender
+        - dateOfBirth
+        - nationality
+        - address
       properties:
         firstName:
           type: string
@@ -387,8 +376,7 @@ components:
           type: string
           description: Last name of the club member
         registrationNumber:
-          type: string
-          description: Registration number of the club member
+          $ref: '#/components/schemas/RegistrationNumber'
         gender:
           type: string
           enum: [ male, female ]
@@ -396,21 +384,19 @@ components:
           type: string
           format: date
           description: Date of birth of the club member
-        birthCertificateNumber:
-          type: string
+        socialSecurityNumber:
+          $ref: '#/components/schemas/SocialSecurityNumber'
         nationality:
           type: string
           description: two letter country code, ISO 3166-1 alpha-2
         address:
           $ref: '#/components/schemas/Address'
         contact:
-          type: object
-          items:
-            $ref: '#/components/schemas/Contact'
+          $ref: '#/components/schemas/Contact'
         guardians:
           type: array
           items:
-            $ref: '#/components/schemas/Guardian'
+            $ref: '#/components/schemas/LegalGuardian'
         siCard:
           properties:
             number:
@@ -419,44 +405,56 @@ components:
         dietaryRestrictions:
           type: string
           description: Dietary restrictions of the club member
-    UpdateUser:
+    UpdateUserForm:
       type: object
       properties:
-        id:
-          type: integer
-          description: Unique identifier for the club member
-        registrationNumber:
-          type: string
-          description: Registration number of the club member
         firstName:
           type: string
-          description: First name of the club member
+          description: |-
+            [Admin] First name of the club member"
         lastName:
           type: string
-          description: Last name of the club member
+          description: |-
+            [Admin] Last name of the club member
         dateOfBirth:
           type: string
           format: date
-          description: Date of birth of the club member
-        birthCertificateNumber:
+          description: |-
+            [Admin] Date of birth of the club member
+        socialSecurityNumber:
           type: string
+          description: |-
+            [Admin]
         identityCard:
-          $ref: '#/components/schemas/IdentityCard'
+          allOf:
+            - $ref: '#/components/schemas/IdentityCard'
+            - description: |-
+                [User]
         nationality:
           type: string
-          description: two letter country code, ISO 3166-1 alpha-2
+          description: |-
+            [Admin] two letter country code, ISO 3166-1 alpha-2
         address:
-          $ref: '#/components/schemas/Address'
+          allOf:
+            - $ref: '#/components/schemas/Address'
+            - description: |-
+                [User]
         contact:
           type: object
+          description: |-
+            [User]
           items:
             $ref: '#/components/schemas/Contact'
         guardians:
           type: array
+          description: |-
+            [User]
           items:
-            $ref: '#/components/schemas/Guardian'
+            $ref: '#/components/schemas/LegalGuardian'
         siCards:
           type: array
+          description: |-
+            [User]
           items:
             type: object
             properties:
@@ -468,21 +466,32 @@ components:
                 description: Whether the contact is primary or not
         gender:
           type: string
+          description: |-
+            [Admin]
           enum: [ male, female ]
         bankAccount:
           type: string
-          description: Bank account number of the club member IBAN
+          description: |-
+            [User] Bank account number of the club member IBAN
         dietaryRestrictions:
           type: string
-          description: Dietary restrictions of the club member
+          description: |-
+            [User] Dietary restrictions of the club member
         drivingLicence:
           type: string
+          description: |-
+            [User]
           enum: [B, BE, C, D, None]
         medicCourse:
           type: boolean
-          description: Whether the club member has completed the medic course
-    Guardian:
+          description: |-
+            [User] Whether the club member has completed the medic course
+    LegalGuardian:
       type: object
+      required:
+        - firstName
+        - lastName
+        - contact
       properties:
         firstName:
           type: string
@@ -491,12 +500,22 @@ components:
           type: string
           description: Last name of the guardian
         contact:
-          type: object
-          items:
-            $ref: '#/components/schemas/Contact'
+          $ref: '#/components/schemas/Contact'
         note:
           type: string
           description: Note about the guardian (matka, otec)
+    OBLicence:
+      type: string
+      enum: [ E, R, A, B, C ]
+      description: License number of the club member
+    RefereeLicence:
+      type: string
+      enum: [ R1, R2, R3 ]
+      description: referee license number of the club member
+    TrainerLicence:
+      type: string
+      enum: [ T1, T2, T3 ]
+      description: trainer license number of the club member
     Licences:
       type: object
       properties:
@@ -504,29 +523,12 @@ components:
           type: object
           properties:
             licence:
-              type: string
-              enum: [ E, R, A, B, C, None ]
-              description: License number of the club member
-            history:
-              type: array
-              items:
-                type: object
-                properties:
-                  licence:
-                    type: string
-                    enum: [ E, R, A, B, C ]
-                    description: License number of the club member
-                  year:
-                    type: string
-                    format: date
-                    description: Date of the license, YYYY-MM-DD
+              $ref: '#/components/schemas/OBLicence'
         referee:
           type: object
           properties:
             licence:
-              type: string
-              enum: [ R1, R2, R3, None ]
-              description: referee license number of the club member
+              $ref: '#/components/schemas/OBLicence'
             expiryDate:
               type: string
               format: date
@@ -535,9 +537,7 @@ components:
           type: object
           properties:
             licence:
-              type: string
-              enum: [ T1, T2, T3, None ]
-              description: trainer license number of the club member
+              $ref: '#/components/schemas/OBLicence'
             expiryDate:
               type: string
               format: date
@@ -554,13 +554,6 @@ components:
             type: string
           description: Reasons why the club member can't be deleted
   securitySchemes:
-    BearerAuth:
-      type: http
-      scheme: bearer
-      description: From email magic link
-    OpenID:
+    klabis:
       type: openIdConnect
-      openIdConnectUrl: https://openid.example.com/.well-known/openid-configuration
-
-
-
+      openIdConnectUrl: https://klabis-auth.polach.cloud/.well-known/openid-configuration

--- a/klabis-api-spec.yaml
+++ b/klabis-api-spec.yaml
@@ -38,14 +38,16 @@ servers:
   - url: https://klabis-auth.polach.cloud
   - url: https://api.klabis.otakar.io
 tags:
-  - name: users
-    description: Members list
+  - name: members
+    description: Club members
   - name: security
     description: API used to control authentication and authorization
   - name: ORIS
     description: Integration endpoints with ORIS - https://oris.orientacnisporty.cz/
   - name: CUS
     description: Integration endpoints with CUS - https://www.cuscz.cz/
+  - name: WIP
+    description: "[odkladiste pro 'work-in-progress' endpointy]"
 security:
   - klabisAuth:
       - openid
@@ -53,7 +55,7 @@ paths:
   /password:
     put:
       tags:
-        - security
+        - WIP
       summary: "[WIP] - Set a new password"
       description: Sets a new password for currently logged in user
       requestBody:
@@ -73,19 +75,19 @@ paths:
           description: Unauthorized
         '500':
           description: Internal Server Error
-  /users:
+  /members:
     get:
       tags:
-        - users
-      summary: List all club users
-      description: Returns a list of all club users
+        - members
+      summary: List all club members
+      description: Returns a list of all club members
       parameters:
         - name: view
           in: query
           required: false
           description: |
             Defines set of returned data
-            - full: all member data what are displayable to logged in user are returned
+            - full: all member data what are displayable to user are returned
             - compact: `id`, `firstName`, `lastName`, 'registrationNumber`
           schema:
             type: string
@@ -106,52 +108,25 @@ paths:
             default: false
       responses:
         '200':
-          description: A list of club users
+          description: A list of club members
           content:
             application/json:
               schema:
                 type: array
                 items:
                   oneOf:
-                    - $ref: '#/components/schemas/User'
-                    - $ref: '#/components/schemas/UserViewCompact'
+                    - $ref: '#/components/schemas/Member'
+                    - $ref: '#/components/schemas/MemberViewCompact'
         '401':
             description: Unauthorized - not logged in
-
-    post:
-      tags:
-        - users
-      summary: Create a new club member
-      description: |
-        Creates a new club member with the provided details.
-        
-        #### Required authorization
-        requires `members:create` grant
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/FormCreateUser'
-      responses:
-        '201':
-          description: New club member created successfully
-        '400':
-          description: Bad request - Invalid data
-        '401':
-          description: Unauthorized - not logged in
-        '409':
-          description: Conflict - User with the same registration number already exists
-        '403':
-            description: Forbidden - User does not have permission to create a member
-  /users/{userId}:
+  /members/{memberId}:
     get:
       tags:
-        - users
-      summary: Get user by ID
-      description: Returns a user
+        - members
+      summary: Get member by ID
+      description: Returns a member
       parameters:
-        - name: userId
+        - name: memberId
           in: path
           required: true
           description: ID of the club member to get
@@ -159,19 +134,19 @@ paths:
             type: integer
       responses:
         '200':
-          description: A single user
+          description: A single member
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/Member'
         '401':
           description: Unauthorized - not logged in
     put:
       tags:
-        - users
-      summary: Update member
+        - members
+      summary: "Update member (TBD: move these edits away and/or split them into 2 endpoints?)"
       parameters:
-        - name: userId
+        - name: memberId
           in: path
           required: true
           schema:
@@ -182,8 +157,8 @@ paths:
           application/json:
             schema:
               oneOf:
-                - $ref: '#/components/schemas/FormUpdateMyUserData'
-                - $ref: '#/components/schemas/FormUpdateUserByAdmin'
+                - $ref: '#/components/schemas/ChangeMyDetailsForm'
+                - $ref: '#/components/schemas/MemberInfoUpdateByAdminForm'
       responses:
         '200':
           description: Club member updated successfully
@@ -193,82 +168,119 @@ paths:
           description: Forbidden - User does not have permission to update a member
         '404':
           description: Club member not found
-  /users/{userId}/archive:
+
+  /memberRegistrations:
+    get:
+      tags:
+        - members
+      summary: Get default values for member registration form
+      description: |
+        Returns default values for member registration form.   
+        
+        - when `orisId` is provided and user with such ID exists in ORIS, then data from ORIS for such user will be returned 
+        - when both `gender` and `sex` parameters are provided, then suggested `registrationNumber` will be returned
+                
+        #### Required authorization
+        requires `members:register` grant
+      parameters:
+        - name: orisId
+          schema:
+            $ref: '#/components/schemas/OrisID'
+            required: false
+          in: query
+          description: ORIS ID of user who shall be registered. When provided, available values obtained from ORIS will be returned if such user is found in the ORIS
+        - name: dateOfBirth
+          in: query
+          schema:
+            type: string
+            format: date
+        - name: gender
+          in: query
+          schema:
+            type: string
+            enum:
+              - male
+              - female
+      responses:
+        '201':
+          description: Registration was processed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MemberRegistrationForm'
+        '400':
+          description: Bad request - Invalid data
+        '409':
+          description: Conflict - User with the same registration number already exists
+        '403':
+          description: Forbidden - User does not have permission to submit registration of new member
+    post:
+      tags:
+        - members
+      summary: Register a new club member
+      description: |
+        Registers a new club member with the provided details.
+        
+        #### Required authorization
+        requires `members:register` grant
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MemberRegistrationForm'
+      responses:
+        '201':
+          description: Registration was processed successfully
+        '400':
+          description: Bad request - Invalid data
+        '403':
+          description: Forbidden - User does not have permission to submit registration of new member
+        '409':
+          description: Conflict - User already exists (usually registration was submitted with existing registration number)
+  /memberDeregistrations/{memberId}:
     put:
       tags:
-        - users
-      summary: Archive member
+        - members
+      summary: Deregister a club member
+      description: |
+        Deregisters a club member. 
+        
+        If there are some blockers (debt, etc), it responds with HTTP 409 unless `force=true` parameter was used.
+
+        #### Required authorization
+        requires `members:deregister` grant
       parameters:
-        - name: userId
+        - name: memberId
           in: path
           required: true
-          description: ID of the club member to archive
+          description: ID of the club member who will be deregistered from club
           schema:
             type: integer
+        - name: force
+          in: query
+          description: Forces user deregistration even if there are some reasons (like negative finance account balance, etc..) why it would be wise to postpone user deregistration
+          required: false
+          schema:
+            type: boolean
+            default: false
       responses:
         '200':
-          description: Club member archived successfully
+          description: Club member deregistration processed successfully
         '403':
           description: Unauthorized - User does not have permission to archive a member
         '404':
           description: Club member not found
-  /users/{userId}/delete-check:
-    get:
-      tags:
-        - users
-      summary: "[WIP] - Check if user can be deleted"
-      description: returns reason why user can't be deleted
-      parameters:
-        - name: userId
-          in: path
-          required: true
-          description: ID of the club member to check
-          schema:
-            type: integer
-      responses:
-        '200':
-          description: Club member can be deleted
+        '409':
+          description: It's not possible to deregister club member. See response body for actual reason(s). You may use `force` to override these reasons.
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/DeleteCheck'
-        '401':
-          description: Unauthorized - not logged in
-        '403':
-            description: Forbidden - User does not have permission to delete a member
-        '404':
-          description: Club member not found
-  /users/registration-number:
-    get:
-      tags:
-        - users
-      summary: "[WIP] - Get a free registration ID"
-      description: Returns a free registration ID that can be used to register a new club member.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                dateOfBirth:
-                  type: string
-                gender:
-                  type: string
-                  enum: [male, female]
-      responses:
-        '200':
-          description: A free registration ID
-          content:
-            application/json:
-              schema:
-                type: string
-                description: A free registration ID
-        '401':
-          description: Unauthorized - not logged in
+              type: string
+              example: TO BE DEFINED
   /cus/exports/members:
     get:
       tags:
-        - CUS
+        - WIP
       summary: "[WIP] - export users in CUS format"
       responses:
         '200':
@@ -277,19 +289,6 @@ paths:
           description: Unauthorized - not logged in
         '403':
           description: Forbidden - User does not have permission to delete a member
-  /oris/users:
-    get:
-      tags:
-        - ORIS
-      summary: "[WIP] - get info about existing user from ORIS"
-      description: used when looking for preexisting user is added to the system
-      responses:
-        '200':
-          description: user info
-        '401':
-          description: Unauthorized - not logged in
-        '403':
-          description: Forbidden - User does not have permission for this
 components:
   schemas:
     CountryCode:
@@ -304,6 +303,9 @@ components:
       type: string
       pattern: ^[A-Z]{3}[0-9]{4}$
       description: ORIS registration number
+    OrisID:
+      type: integer
+      description: Oris ID of registered orienteering runner
     DrivingLicence:
       type: string
       enum: [ B, BE, C, D, None ]
@@ -351,7 +353,7 @@ components:
           type: string
           format: date
           description: Expiry date of the ID card, YYYY-MM-DD
-    UserViewCompact:
+    MemberViewCompact:
       type: object
       required:
         - id
@@ -371,12 +373,18 @@ components:
           description: Last name of the club member
         registrationNumber:
           $ref: '#/components/schemas/RegistrationNumber'
-    User:
+    Member:
       allOf:
-        - $ref: '#/components/schemas/UserViewCompact'
+        - $ref: '#/components/schemas/MemberViewCompact'
         - type: object
           required:
             - id
+            - firstName
+            - lastName
+            - gender
+            - dateOfBirth
+            - nationality
+            - address
           properties:
             id:
               type: integer
@@ -421,13 +429,13 @@ components:
             medicCourse:
               type: boolean
               description: Whether the club member has completed the medic course
-    FormCreateUser:
+    MemberRegistrationForm:
       type: object
       description: |-
-        Data required to create new member.  
+        Data required to register new member.  
         
         #### Required authorization
-        - requires `members:create` grant
+        - requires `members:register` grant
         
         Additional validations: 
         - either contact or guardian needs to be set
@@ -446,8 +454,6 @@ components:
         lastName:
           type: string
           description: Last name of the club member
-        registrationNumber:
-          $ref: '#/components/schemas/RegistrationNumber'
         gender:
           type: string
           enum: [ male, female ]
@@ -457,25 +463,38 @@ components:
           description: Date of birth of the club member
         birthCertificateNumber:
           $ref: '#/components/schemas/BirthCertificateNumber'
+          writeOnly: true
         nationality:
           $ref: '#/components/schemas/CountryCode'
+          writeOnly: true
         address:
           $ref: '#/components/schemas/Address'
+          writeOnly: true
         contact:
           $ref: '#/components/schemas/Contact'
+          writeOnly: true
         guardians:
           type: array
+          writeOnly: true
           items:
             $ref: '#/components/schemas/LegalGuardian'
         siCard:
           $ref: '#/components/schemas/SICard'
-        dietaryRestrictions:
-          type: string
-          description: Dietary restrictions of the club member
-    FormUpdateUserByAdmin:
+        bankAccount:
+          $ref: '#/components/schemas/BankAccountNumber'
+          writeOnly: true
+        registrationNumber:
+          $ref: '#/components/schemas/RegistrationNumber'
+        orisId:
+          $ref: '#/components/schemas/OrisID'
+          writeOnly: true
+#        trainingGroup:
+#          type: ???
+#          description: training group where newly registered member will be added
+    MemberInfoUpdateByAdminForm:
       type: object
       description: |-
-        Member attributes editable by admin user = user holding grant [TBD]
+        Member attributes editable by TBD-"vedeni".
 
         #### Required authorization
         - requires `members:edit` grant
@@ -506,7 +525,7 @@ components:
         gender:
           type: string
           enum: [ male, female ]
-    FormUpdateMyUserData:
+    ChangeMyDetailsForm:
       description: |
         Member attributes which can be updated by member himself (member can update some own attributes)  
         
@@ -613,17 +632,6 @@ components:
           $ref: '#/components/schemas/RefereeLicence'
         trainer:
           $ref: '#/components/schemas/TrainerLicence'
-    DeleteCheck:
-      type: object
-      properties:
-        success:
-          type: boolean
-          description: Whether the club member can be deleted or not
-        errors:
-          type: array
-          items:
-            type: string
-          description: Reasons why the club member can't be deleted
     GlobalGrants:
       type: string
       description: |
@@ -631,11 +639,13 @@ components:
         
         | Grant name | granted permissions |
         | --- | --- |
-        | `members:create` | can create new members |
+        | `members:register` | can create new members |
         | `members:edit` | can edit "admin" attributes for existing members |
+        | `members:deregister` | can deregister club members |
       enum:
-        - members:create
+        - members:register
         - members:edit
+        - members:deregister
     MemberSpecificGrants:
       type: string
       description: |

--- a/klabis-api-spec.yaml
+++ b/klabis-api-spec.yaml
@@ -22,18 +22,23 @@ info:
     - user may allow another member to perform operation on his behalf/view his data
     - user is granted permission to perform operation on behalf of another member / view another member's data because of membership/leadership of user group
 
+    Operations / data protected by this type of grant can be automatically performed if user is same person as member who is described by protected data or if operation is changing data of such member.   
+
     ### What authorization is required to use API endpoint?
     If endpoint requires authorization, it is written in description text of such endpoint with label "Required authorization"
     
     ### What authorization is required to see value of attribute in the response?
     Response attributes: even some attributes in the response may require specific grant - see description of the attribute in response OpenAPI/JSON schema. If user doesn't hold such grant, attribute will be returned as empty (null)  
 
+    ## API versioning
+    To be added later (before first production release). At current stage it's not needed. Most likely either contentType or request header versioning strategy will be used.  
+
   contact:
     email: klabis@otakar.io
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT
-  version: 0.1.12
+  version: 0.2.1
 servers:
   - url: https://klabis-auth.polach.cloud
   - url: https://api.klabis.otakar.io
@@ -158,7 +163,7 @@ paths:
             schema:
               oneOf:
                 - $ref: '#/components/schemas/ChangeMyDetailsForm'
-                - $ref: '#/components/schemas/MemberInfoUpdateByAdminForm'
+                - $ref: '#/components/schemas/MemberInfoUpdateByMembersManagerForm'
       responses:
         '200':
           description: Club member updated successfully
@@ -173,12 +178,13 @@ paths:
     get:
       tags:
         - members
-      summary: Get default values for member registration form
+      summary: Get values to be prefilled in member registration form
       description: |
-        Returns default values for member registration form.   
+        Returns values to be prefilled in member registration form.   
         
-        - when `orisId` is provided and user with such ID exists in ORIS, then data from ORIS for such user will be returned 
-        - when both `gender` and `sex` parameters are provided, then suggested `registrationNumber` will be returned
+        - when `orisId` is provided and user with such ID exists in ORIS, then data from ORIS for such user will be returned (`firstName`, `lastName`, `registrationNumber`, etc..)
+        - when both `sex` and `sex` parameters are provided, then suggested `registrationNumber` will be returned
+        - when `oris`, `sex` and `sex` are provided and registration number is available in ORIS, then registration number from ORIS will be returned
                 
         #### Required authorization
         requires `members:register` grant
@@ -194,13 +200,10 @@ paths:
           schema:
             type: string
             format: date
-        - name: gender
+        - name: sex
           in: query
           schema:
-            type: string
-            enum:
-              - male
-              - female
+            $ref: '#/components/schemas/Sex'
       responses:
         '201':
           description: Registration was processed successfully
@@ -308,10 +311,15 @@ components:
       description: Oris ID of registered orienteering runner
     DrivingLicence:
       type: string
-      enum: [ B, BE, C, D, None ]
+      enum: [ B, BE, C, D ]
     SICard:
       type: number
       description: SI chip used by member
+    Sex:
+      type: string
+      enum:
+        - male
+        - female
     Contact:
       type: object
       description: At least one of email or phone value is required
@@ -381,7 +389,7 @@ components:
             - id
             - firstName
             - lastName
-            - gender
+            - sex
             - dateOfBirth
             - nationality
             - address
@@ -413,8 +421,7 @@ components:
             nationality:
               $ref: '#/components/schemas/CountryCode'
             sex:
-              type: string
-              enum: [male, female]
+              $ref: '#/components/schemas/Sex'
             licences:
               $ref: '#/components/schemas/Licences'
             bankAccount:
@@ -443,7 +450,7 @@ components:
       required:
         - firstName
         - lastName
-        - gender
+        - sex
         - dateOfBirth
         - nationality
         - address
@@ -454,9 +461,8 @@ components:
         lastName:
           type: string
           description: Last name of the club member
-        gender:
-          type: string
-          enum: [ male, female ]
+        sex:
+          $ref: '#/components/schemas/Sex'
         dateOfBirth:
           type: string
           format: date
@@ -487,11 +493,10 @@ components:
           $ref: '#/components/schemas/RegistrationNumber'
         orisId:
           $ref: '#/components/schemas/OrisID'
-          writeOnly: true
 #        trainingGroup:
 #          type: ???
 #          description: training group where newly registered member will be added
-    MemberInfoUpdateByAdminForm:
+    MemberInfoUpdateByMembersManagerForm:
       type: object
       description: |-
         Member attributes editable by TBD-"vedeni".
@@ -506,7 +511,7 @@ components:
         - lastName
         - dateOfBirth
         - nationality
-        - gender
+        - sex
       properties:
         firstName:
           type: string
@@ -522,9 +527,8 @@ components:
           $ref: '#/components/schemas/BirthCertificateNumber'
         nationality:
           $ref: '#/components/schemas/CountryCode'
-        gender:
-          type: string
-          enum: [ male, female ]
+        sex:
+          $ref: '#/components/schemas/Sex'
     ChangeMyDetailsForm:
       description: |
         Member attributes which can be updated by member himself (member can update some own attributes)  
@@ -640,7 +644,7 @@ components:
         | Grant name | granted permissions |
         | --- | --- |
         | `members:register` | can create new members |
-        | `members:edit` | can edit "admin" attributes for existing members |
+        | `members:edit` | can edit selected attributes for all existing members |
         | `members:deregister` | can deregister club members |
       enum:
         - members:register

--- a/klabis-api-spec.yaml
+++ b/klabis-api-spec.yaml
@@ -143,14 +143,14 @@ paths:
         '401':
           description: Unauthorized - not logged in
 
-  /members/{memberId}/changeMemberInfo:
+  /members/{memberId}/editMemberInfoForm:
     parameters:
       - name: memberId
         in: path
         required: true
         schema:
           type: integer
-    put:
+    post:
       tags:
         - members
       summary: "Update member information"
@@ -159,9 +159,9 @@ paths:
         content:
           application/json:
             schema:
-              oneOf:
-                - $ref: '#/components/schemas/ChangeMyDetailsForm'
-                - $ref: '#/components/schemas/MemberInfoUpdateByMembersManagerForm'
+              anyOf:
+                - $ref: '#/components/schemas/EditMyDetailsForm'
+                - $ref: '#/components/schemas/EditAnotherMemberDetailsForm'
       responses:
         '200':
           description: Club member updated successfully
@@ -174,7 +174,7 @@ paths:
         '404':
           description: Club member not found
 
-  /members/{memberId}/suspendMembership:
+  /members/{memberId}/suspendMembershipForm:
     parameters:
       - name: memberId
         in: path
@@ -198,19 +198,15 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - canSuspend
+                  - details
                 properties:
                   canSuspend:
                     type: boolean
                     description: tells if member account can be suspended
                   details:
-                    type: object
-                    properties:
-                      finance:
-                        type: object
-                        properties:
-                          status:
-                            type: boolean
-                            description: tells if finance account balance permits membership suspension
+                    $ref: '#/components/schemas/SuspendMembershipBlockers'
         403:
           description: Unauthorized - User does not have permission to suspend membership
         404:
@@ -245,9 +241,13 @@ paths:
           description: It's not possible to suspend membership for club member. See response body for actual reason(s). You may use `force` to override these reasons.
           content:
             application/json:
-              type: string
-              example: TO BE DEFINED
-
+              schema:
+                type: object
+                required:
+                  - blockers
+                properties:
+                  blockers:
+                    $ref: '#/components/schemas/SuspendMembershipBlockers'
   /registrationNumber:
     get:
       tags:
@@ -268,15 +268,15 @@ paths:
             $ref: '#/components/schemas/Sex'
       responses:
         200:
-          description: Recommended registration number for new member registration
+          description: Recommended (available) registration number for new member registration
           content:
             application/json:
               schema:
                 type: object
                 required:
-                  - registrationNumber
+                  - availableRegistrationNumber
                 properties:
-                  registrationNumber:
+                  availableRegistrationNumber:
                     $ref: '#/components/schemas/RegistrationNumber'
         400:
           description: Bad request - Invalid data
@@ -576,10 +576,10 @@ components:
 #        trainingGroup:
 #          type: ???
 #          description: training group where newly registered member will be added
-    MemberInfoUpdateByMembersManagerForm:
+    EditAnotherMemberDetailsForm:
       type: object
       description: |-
-        Member attributes editable by TBD-"vedeni".
+        Member attributes editable by authorized user who can change details about other members
 
         #### Required authorization
         - requires `members:edit` grant
@@ -609,7 +609,7 @@ components:
           $ref: '#/components/schemas/CountryCode'
         sex:
           $ref: '#/components/schemas/Sex'
-    ChangeMyDetailsForm:
+    EditMyDetailsForm:
       description: |
         Member attributes which can be updated by member himself (member can update some own attributes)  
         
@@ -716,6 +716,20 @@ components:
           $ref: '#/components/schemas/RefereeLicence'
         trainer:
           $ref: '#/components/schemas/TrainerLicence'
+    SuspendMembershipBlockers:
+      type: object
+      description: describes conditions which may prevent membership suspension and their actual status
+      required:
+        - finance
+      properties:
+        finance:
+          type: object
+          required:
+            - status
+          properties:
+            status:
+              type: boolean
+              description: tells if finance account balance permits membership suspension
     GlobalGrants:
       type: string
       description: |

--- a/klabis-api-spec.yaml
+++ b/klabis-api-spec.yaml
@@ -273,6 +273,9 @@ components:
     Contact:
       type: object
       description: At least one of email or phone value is required
+      required:
+        - email
+        - phone
       properties:
         email:
           type: string
@@ -457,6 +460,8 @@ components:
       properties:
         identityCard:
           $ref: '#/components/schemas/IdentityCard'
+        nationality:
+          $ref: '#/components/schemas/CountryCode'
         address:
           $ref: '#/components/schemas/Address'
         contact:

--- a/klabis-api-spec.yaml
+++ b/klabis-api-spec.yaml
@@ -1,7 +1,33 @@
 openapi: 3.1.0
 info:
   title: Klabis - OpenAPI 3.1
-  description: Klabis API docs
+  description: |
+    Klabis API docs
+
+    ## Glossary
+    - `member` - club member who can use the application   
+    - `user` - logged in member
+    - `grant` - configurable permission allowing user to perform selected action or view some data
+    
+    ## Authorization
+    Every operation changing data (and some view requests) require `grant` which represents permission for the user to perform such operation.   
+    
+    There are 2 types of grants: 
+    
+    ### Global grants
+    These grants are assigned to user and are valid globally in the application. They grant permission for operations like Create new member, etc. 
+    
+    ### Member specific grants
+    These grants represents permission to perform operation (or view data) on behalf of selected user. User can receive this grant in two ways:
+    - user may allow another member to perform operation on his behalf/view his data
+    - user is granted permission to perform operation on behalf of another member / view another member's data because of membership/leadership of user group
+
+    ### What authorization is required to use API endpoint?
+    If endpoint requires authorization, it is written in description text of such endpoint with label "Required authorization"
+    
+    ### What authorization is required to see value of attribute in the response?
+    Response attributes: even some attributes in the response may require specific grant - see description of the attribute in response OpenAPI/JSON schema. If user doesn't hold such grant, attribute will be returned as empty (null)  
+
   contact:
     email: klabis@otakar.io
   license:
@@ -16,9 +42,9 @@ tags:
     description: Members list
   - name: security
     description: API used to control authentication and authorization
-  - name: oris
+  - name: ORIS
     description: Integration endpoints with ORIS - https://oris.orientacnisporty.cz/
-  - name: cus
+  - name: CUS
     description: Integration endpoints with CUS - https://www.cuscz.cz/
 security:
   - klabisAuth:
@@ -29,8 +55,7 @@ paths:
       tags:
         - security
       summary: "[WIP] - Set a new password"
-      description: >
-        Sets a new password for currently logged in user
+      description: Sets a new password for currently logged in user
       requestBody:
         required: true
         content:
@@ -97,8 +122,11 @@ paths:
       tags:
         - users
       summary: Create a new club member
-      description: >
+      description: |
         Creates a new club member with the provided details.
+        
+        #### Required authorization
+        requires `members:create` grant
       requestBody:
         required: true
         content:
@@ -189,8 +217,7 @@ paths:
       tags:
         - users
       summary: "[WIP] - Check if user can be deleted"
-      description: >
-            returns reason why user can't be deleted
+      description: returns reason why user can't be deleted
       parameters:
         - name: userId
           in: path
@@ -216,8 +243,7 @@ paths:
       tags:
         - users
       summary: "[WIP] - Get a free registration ID"
-      description: >
-        Returns a free registration ID that can be used to register a new club member.
+      description: Returns a free registration ID that can be used to register a new club member.
       requestBody:
         content:
           application/json:
@@ -242,7 +268,7 @@ paths:
   /cus/exports/members:
     get:
       tags:
-        - cus
+        - CUS
       summary: "[WIP] - export users in CUS format"
       responses:
         '200':
@@ -254,8 +280,8 @@ paths:
   /oris/users:
     get:
       tags:
-        - oris
-      summary: "[WIP] - get info about existing user from oris"
+        - ORIS
+      summary: "[WIP] - get info about existing user from ORIS"
       description: used when looking for preexisting user is added to the system
       responses:
         '200':
@@ -400,6 +426,9 @@ components:
       description: |-
         Data required to create new member.  
         
+        #### Required authorization
+        - requires `members:create` grant
+        
         Additional validations: 
         - either contact or guardian needs to be set
         - when nationality is different than `CZ`, `birthCertificateNumber` value will be ignored
@@ -447,7 +476,10 @@ components:
       type: object
       description: |-
         Member attributes editable by admin user = user holding grant [TBD]
-        
+
+        #### Required authorization
+        - requires `members:edit` grant
+       
         Additional validations: 
         - when `CZ` is selected as nationality, then `birthCertificateNumber` is required value
       required:
@@ -459,17 +491,14 @@ components:
       properties:
         firstName:
           type: string
-          description: |-
-            First name of the club member
+          description: First name of the club member
         lastName:
           type: string
-          description: |-
-            Last name of the club member
+          description: Last name of the club member
         dateOfBirth:
           type: string
           format: date
-          description: |-
-            Date of birth of the club member
+          description: Date of birth of the club member
         birthCertificateNumber:
           $ref: '#/components/schemas/BirthCertificateNumber'
         nationality:
@@ -478,9 +507,12 @@ components:
           type: string
           enum: [ male, female ]
     FormUpdateMyUserData:
-      description: |-
+      description: |
         Member attributes which can be updated by member himself (member can update some own attributes)  
         
+        #### Required authorization
+        - user can edit own member data 
+
         Additional validations:
         - either contact or at least 1 guardian needs to be entered
       required:
@@ -505,16 +537,14 @@ components:
           $ref: '#/components/schemas/BankAccountNumber'
         dietaryRestrictions:
           type: string
-          description: |-
-            Dietary restrictions of the club member
+          description: Dietary restrictions of the club member
         drivingLicence:
           type: array
           items:
             $ref: '#/components/schemas/DrivingLicence'
         medicCourse:
           type: boolean
-          description: |-
-            Whether the club member has completed the medic course
+          description: Whether the club member has completed the medic course
     LegalGuardian:
       type: object
       required:
@@ -536,8 +566,7 @@ components:
     BankAccountNumber:
       type: string
       pattern: ^[A-Z]{2}[0-9]+$
-      description: |-
-        Bank account number of the club member IBAN
+      description: Bank account number of the club member IBAN
     OBLicence:
       type: object
       required:
@@ -595,6 +624,32 @@ components:
           items:
             type: string
           description: Reasons why the club member can't be deleted
+    GlobalGrants:
+      type: string
+      description: |
+        Global grants are assigned to users and are valid globally in the application.
+        
+        | Grant name | granted permissions |
+        | --- | --- |
+        | `members:create` | can create new members |
+        | `members:edit` | can edit "admin" attributes for existing members |
+      enum:
+        - members:create
+        - members:edit
+    MemberSpecificGrants:
+      type: string
+      description: |
+        Member specific grants are defined between 2 users (user is allowed to perform specific action on behalf of another user). These define fine-grained permissions and can be granted explicitely to selected users or through permissions granted from membership between members of user groups.
+
+        | Grant name | granted permissions |
+        | --- | --- |
+        | `members#canDisplayMemberPersonalContact` | can display personal contact information of member |
+        | `members#canDisplayMemberLegalGuardianContact` | can display contact information of legal guardian of member |
+        | `members#canDisplayMemberAddress` | can display contact information of legal guardian of member |
+      enum:
+        - members#canDisplayMemberPersonalContact
+        - members#canDisplayMemberLegalGuardianContact
+        - members#canDisplayMemberAddress
   securitySchemes:
     klabis:
       type: openIdConnect

--- a/klabis-api-spec.yaml
+++ b/klabis-api-spec.yaml
@@ -164,27 +164,15 @@ paths:
         '404':
           description: Club member not found
 
-  /memberRegistrations:
+  /registrationNumber:
     get:
       tags:
         - members
-      summary: Get values to be prefilled in member registration form
+      summary: Get recommended registration number for sex and date of birth
       description: |
-        Returns values to be prefilled in member registration form.   
-        
-        - when `orisId` is provided and user with such ID exists in ORIS, then data from ORIS for such user will be returned (`firstName`, `lastName`, `registrationNumber`, etc..)
-        - when both `sex` and `sex` parameters are provided, then suggested `registrationNumber` will be returned
-        - when `oris`, `sex` and `sex` are provided and registration number is available in ORIS, then registration number from ORIS will be returned
-                
         #### Required authorization
         requires `members:register` grant
       parameters:
-        - name: orisId
-          schema:
-            $ref: '#/components/schemas/OrisID'
-            required: false
-          in: query
-          description: ORIS ID of user who shall be registered. When provided, available values obtained from ORIS will be returned if such user is found in the ORIS
         - name: dateOfBirth
           in: query
           schema:
@@ -195,18 +183,48 @@ paths:
           schema:
             $ref: '#/components/schemas/Sex'
       responses:
-        '201':
-          description: Registration was processed successfully
+        200:
+          description: Recommended registration number for new member registration
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MemberRegistrationForm'
-        '400':
+                type: object
+                required:
+                  - registrationNumber
+                properties:
+                  registrationNumber:
+                    $ref: '#/components/schemas/RegistrationNumber'
+        400:
           description: Bad request - Invalid data
-        '409':
-          description: Conflict - User with the same registration number already exists
-        '403':
+
+  /oris/userInfo/{orisId}:
+    get:
+      tags:
+        - ORIS
+      summary: Get information about user from ORIS
+      description: |
+        #### Required authorization
+        requires `members:register` grant
+      parameters:
+        - name: orisId
+          schema:
+            $ref: '#/components/schemas/OrisID'
+            required: false
+          in: path
+          description: ORIS ID of user to retrieve ORIS data about
+      responses:
+        200:
+          description: Available information about user read from ORIS
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ORISUserInfo'
+        400:
+          description: Bad request - Invalid data
+        403:
           description: Forbidden - User does not have permission to submit registration of new member
+
+  /memberRegistrations:
     post:
       tags:
         - members
@@ -463,6 +481,29 @@ components:
               type: boolean
               description: Whether the club member has completed the medic course
         - description: Member attributes
+
+    ORISUserInfo:
+      type: object
+      description: |-
+        User data retrieved from ORIS  
+        
+        #### Required authorization
+        - requires `members:register` grant
+      required:
+        - firstName
+        - lastName
+        - registrationNumber
+      properties:
+        firstName:
+          type: string
+          description: First name of the club member
+        lastName:
+          type: string
+          description: Last name of the club member
+        registrationNumber:
+          $ref: '#/components/schemas/RegistrationNumber'
+        orisId:
+          $ref: '#/components/schemas/OrisID'
 
     MemberRegistrationForm:
       type: object

--- a/klabis-api-spec.yaml
+++ b/klabis-api-spec.yaml
@@ -53,9 +53,6 @@ tags:
     description: Integration endpoints with CUS - https://www.cuscz.cz/
   - name: WIP
     description: "[odkladiste pro 'work-in-progress' endpointy]"
-security:
-  - klabisAuth:
-      - openid
 paths:
   /password:
     put:
@@ -672,3 +669,6 @@ components:
     klabis:
       type: openIdConnect
       openIdConnectUrl: https://klabis-auth.polach.cloud/.well-known/openid-configuration
+security:
+  - klabis:
+      - openid


### PR DESCRIPTION
Here are changes for users API pieces to align them closer to our requirements. 

There are 3 things what I am still thinking about:
1. do we need surrogate UUID for member? Why not use registration number in that place? (= will be there any users who are not members with registration number?). Maybe topic for Wednesday call. 
2. Update member data by member himself and by "admin" (or as I suggest - user with `members:edit` grant). I am not fully convinced that it should be single endpoint `PUT /members/{memberId}` - especially because there may be things on that page what may not belong to member itself. One such thing could be information about training group where member belongs. Because of that, it would fit more into "form" endpoints (like registration form) as such action doesn't represent update of member entity only but some action affecting more parts of the application. 
3. HATEOAS / action links to pass information to UI which actions are allowed for user on given piece of application data. 