### PR TITLE
Member edit form split into two

### DIFF
--- a/backend/api.http
+++ b/backend/api.http
@@ -83,6 +83,56 @@ Authorization: Bearer {{$auth.token("frontend")}}
   "sex": "male"
 }
 
+### Get form data for Member Edit by Admin
+GET {{host}}/members/1/editByAdminForm
+Authorization: Bearer {{$auth.token("frontend")}}
+
+### Update member info by ADMIN
+PUT {{host}}/members/1/editByAdminForm
+Content-Type: application/json
+Authorization: Bearer {{$auth.token("frontend")}}
+
+{
+  "firstName": "Dave",
+  "lastName": "Pol",
+  "dateOfBirth": "1982-04-26",
+  "birthCertificateNumber": "123456/780",
+  "nationality": "CZ",
+  "sex": "male"
+}
+
+###
+GET {{host}}/members/1/editOwnMemberInfoForm
+Authorization: Bearer {{$auth.token("frontend")}}
+
+###
+PUT {{host}}/members/1/editOwnMemberInfoForm
+Authorization: Bearer {{$auth.token("frontend")}}
+Content-Type: application/json
+
+{
+  "identityCard": null,
+  "nationality": "CZ",
+  "address": {
+    "streetAndNumber": "Nekde jinde 12",
+    "city": "Brno",
+    "postalCode": "63212",
+    "country": "CZ"
+  },
+  "contact": {
+    "email": "test@testx.com",
+    "phone": "888888888",
+    "note": null
+  },
+  "guardians": [],
+  "siCard": 12345678,
+  "bankAccount": "CZ1234567891000",
+  "dietaryRestrictions": null,
+  "drivingLicence": [],
+  "medicCourse": false
+}
+
+
 ### Membership suspension info
 GET {{host}}/members/1/suspendMembershipForm
 Authorization: Bearer {{$auth.token("frontend")}}

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -77,7 +77,7 @@ dependencies {
     //implementation("org.jmolecules:jmolecules-hexagonal-architecture:1.9.0")
     implementation("org.jmolecules:jmolecules-onion-architecture:1.9.0")
     implementation("org.jmolecules:jmolecules-events:1.9.0")
-    testImplementation("org.jmolecules.integrations:jmolecules-archunit:1.6.0")
+    testImplementation("org.jmolecules.integrations:jmolecules-archunit:0.20.0")
     testImplementation("com.tngtech.archunit:archunit-junit5:1.3.0")
 }
 

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -25,8 +25,8 @@ description = "klabis"
 java.sourceCompatibility = JavaVersion.VERSION_21
 
 val recordbuilderVersion = "41"
-val mapstructVersion = "1.6.0.Beta1"
-val mapstructSpringExtensionsVersion = "1.1.1"
+val mapstructVersion = "1.6.2"
+val mapstructSpringExtensionsVersion = "1.1.2"
 
 dependencies {
 
@@ -77,7 +77,7 @@ dependencies {
     //implementation("org.jmolecules:jmolecules-hexagonal-architecture:1.9.0")
     implementation("org.jmolecules:jmolecules-onion-architecture:1.9.0")
     implementation("org.jmolecules:jmolecules-events:1.9.0")
-    testImplementation("org.jmolecules.integrations:jmolecules-archunit:0.20.0")
+    testImplementation("org.jmolecules.integrations:jmolecules-archunit:1.6.0")
     testImplementation("com.tngtech.archunit:archunit-junit5:1.3.0")
 }
 
@@ -132,8 +132,10 @@ openApiGenerate {
             //"hateoas" to "false",
             "booleanGetterPrefix" to "is",
             "interfaceOnly" to "true",
-            "defaultInterfaces" to "false",
-            "useBeanValidation" to "true"
+            "skipDefaultInterface" to "true",
+            "useBeanValidation" to "true",
+            "apiFirst" to "false"
+            //"useOptional" to "false"
         )
     )
 }

--- a/backend/src/main/java/club/klabis/adapters/api/members/MembersController.java
+++ b/backend/src/main/java/club/klabis/adapters/api/members/MembersController.java
@@ -66,7 +66,7 @@ public class MembersController implements MembersApi {
     }
 
     @Override
-    public ResponseEntity<Void> membersMemberIdSuspendMembershipFormPost(Integer memberId, Boolean force) {
+    public ResponseEntity<Void> membersMemberIdSuspendMembershipFormPut(Integer memberId, Boolean force) {
         service.suspendMembershipForMember(memberId, force);
         return ResponseEntity.ok(null);
     }

--- a/backend/src/main/java/club/klabis/adapters/api/members/MembersController.java
+++ b/backend/src/main/java/club/klabis/adapters/api/members/MembersController.java
@@ -8,11 +8,14 @@ import club.klabis.domain.appusers.ApplicationUserService;
 import club.klabis.domain.members.Member;
 import club.klabis.domain.members.MemberNotFoundException;
 import club.klabis.domain.members.MemberService;
+import club.klabis.domain.members.forms.EditAnotherMemberInfoByAdminForm;
+import club.klabis.domain.members.forms.EditOwnMemberInfoForm;
 import club.klabis.domain.members.forms.MemberEditForm;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Collection;
@@ -98,4 +101,25 @@ public class MembersController implements MembersApi {
         return ResponseEntity.ok(null);
     }
 
+    @Override
+    public ResponseEntity<EditAnotherMemberDetailsFormApiDto> getMemberEditByAdminForm(Integer memberId) {
+        return ResponseEntity.ok(conversionService.convert(service.getEditAnotherMemberForm(memberId), EditAnotherMemberDetailsFormApiDto.class));
+    }
+
+    @Override
+    public ResponseEntity<Void> putMemberEditByAdminForm(Integer memberId, EditAnotherMemberDetailsFormApiDto editAnotherMemberDetailsFormApiDto) {
+        service.editMember(memberId, conversionService.convert(editAnotherMemberDetailsFormApiDto, EditAnotherMemberInfoByAdminForm.class));
+        return ResponseEntity.ok(null);
+    }
+
+    @Override
+    public ResponseEntity<EditMyDetailsFormApiDto> membersMemberIdEditOwnMemberInfoFormGet(Integer memberId) {
+        return ResponseEntity.ok(conversionService.convert(service.getEditOwnMemberInfoForm(memberId), EditMyDetailsFormApiDto.class));
+    }
+
+    @Override
+    public ResponseEntity<Void> membersMemberIdEditOwnMemberInfoFormPut(Integer memberId, EditMyDetailsFormApiDto editMyDetailsFormApiDto) {
+        service.editMember(memberId, conversionService.convert(editMyDetailsFormApiDto, EditOwnMemberInfoForm.class));
+        return ResponseEntity.ok(null);
+    }
 }

--- a/backend/src/main/java/club/klabis/adapters/api/members/MembersRegistrationController.java
+++ b/backend/src/main/java/club/klabis/adapters/api/members/MembersRegistrationController.java
@@ -23,7 +23,7 @@ public class MembersRegistrationController implements MemberRegistrationsApi {
     }
 
     @Override
-    public ResponseEntity<Void> memberRegistrationsPost(MemberRegistrationFormApiDto memberRegistrationFormApiDto) {
+    public ResponseEntity<Void> memberRegistrationsPut(MemberRegistrationFormApiDto memberRegistrationFormApiDto) {
         Member createdMember = service.registerMember(conversionService.convert(memberRegistrationFormApiDto, RegistrationForm.class));
         return ResponseEntity.created(URI.create("/members/%s".formatted(createdMember.getId()))).header("MemberId", "%d".formatted(createdMember.getId())).build();
     }

--- a/backend/src/main/java/club/klabis/adapters/api/members/mappers/EditAnotherMemberInfoByAdminFormMappers.java
+++ b/backend/src/main/java/club/klabis/adapters/api/members/mappers/EditAnotherMemberInfoByAdminFormMappers.java
@@ -1,0 +1,25 @@
+package club.klabis.adapters.api.members.mappers;
+
+import club.klabis.api.dto.EditAnotherMemberDetailsFormApiDto;
+import club.klabis.common.mapstruct.DomainFormMapperConfiguration;
+import club.klabis.domain.members.Member;
+import club.klabis.domain.members.forms.EditAnotherMemberInfoByAdminForm;
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.extensions.spring.DelegatingConverter;
+import org.springframework.core.convert.converter.Converter;
+
+@Mapper(config = DomainFormMapperConfiguration.class, unmappedSourcePolicy = ReportingPolicy.IGNORE)
+interface EditAnotherMemberInfoByAdminFormMappers extends Converter<EditAnotherMemberInfoByAdminForm, EditAnotherMemberDetailsFormApiDto> {
+
+    @Override
+    EditAnotherMemberDetailsFormApiDto convert(EditAnotherMemberInfoByAdminForm source);
+
+    @InheritInverseConfiguration
+    @DelegatingConverter
+    EditAnotherMemberInfoByAdminForm convertReverse(EditAnotherMemberDetailsFormApiDto source);
+
+    @DelegatingConverter
+    EditAnotherMemberInfoByAdminForm fromDomain(Member member);
+}

--- a/backend/src/main/java/club/klabis/adapters/api/members/mappers/MemberEditOwnInfoFormApiDtoFromMemberDomainMapper.java
+++ b/backend/src/main/java/club/klabis/adapters/api/members/mappers/MemberEditOwnInfoFormApiDtoFromMemberDomainMapper.java
@@ -1,0 +1,26 @@
+package club.klabis.adapters.api.members.mappers;
+
+import club.klabis.api.dto.EditMyDetailsFormApiDto;
+import club.klabis.common.mapstruct.DomainFormMapperConfiguration;
+import club.klabis.domain.members.Member;
+import club.klabis.domain.members.forms.EditOwnMemberInfoForm;
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.extensions.spring.DelegatingConverter;
+import org.springframework.core.convert.converter.Converter;
+
+@Mapper(config = DomainFormMapperConfiguration.class)
+interface MemberEditOwnInfoFormApiDtoFromMemberDomainMapper extends Converter<EditOwnMemberInfoForm, EditMyDetailsFormApiDto> {
+    @Override
+    EditMyDetailsFormApiDto convert(EditOwnMemberInfoForm source);
+
+    @InheritInverseConfiguration
+    @DelegatingConverter
+    EditOwnMemberInfoForm convertReverse(EditMyDetailsFormApiDto source);
+
+    @Mapping(target = "guardians", source = "legalGuardians")
+    @Mapping(target = "contact", source = "contact")
+    @DelegatingConverter
+    EditOwnMemberInfoForm fromDomain(Member member);
+}

--- a/backend/src/main/java/club/klabis/adapters/api/oris/OrisProxyController.java
+++ b/backend/src/main/java/club/klabis/adapters/api/oris/OrisProxyController.java
@@ -1,4 +1,4 @@
-package club.klabis.domain.oris;
+package club.klabis.adapters.api.oris;
 
 import club.klabis.adapters.oris.OrisApiClient;
 import club.klabis.api.OrisApi;

--- a/backend/src/main/java/club/klabis/adapters/api/oris/OrisUserInfoMapper.java
+++ b/backend/src/main/java/club/klabis/adapters/api/oris/OrisUserInfoMapper.java
@@ -1,4 +1,4 @@
-package club.klabis.domain.oris;
+package club.klabis.adapters.api.oris;
 
 import club.klabis.adapters.oris.OrisApiClient;
 import club.klabis.common.mapstruct.DomainToDtoMapperConfiguration;

--- a/backend/src/main/java/club/klabis/adapters/oris/OrisApiClient.java
+++ b/backend/src/main/java/club/klabis/adapters/oris/OrisApiClient.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 
 public interface OrisApiClient {
 
-    @GetExchange("/API/?format=xml&method=getUser")
+    @GetExchange("/API/?format=json&method=getUser")
     OrisResponse<OrisUserInfo> getUserInfo(@RequestParam("rgnum") String registrationNumber);
 
     record OrisResponse<T> (

--- a/backend/src/main/java/club/klabis/common/mapstruct/DomainFormMapperConfiguration.java
+++ b/backend/src/main/java/club/klabis/common/mapstruct/DomainFormMapperConfiguration.java
@@ -1,0 +1,13 @@
+package club.klabis.common.mapstruct;
+
+import club.klabis.common.ConversionServiceAdapter;
+import org.mapstruct.MapperConfig;
+import org.mapstruct.ReportingPolicy;
+
+/**
+ * Mapstruct configuration for API DTO mappers.
+ * These mappers shall implement `Converter<DOMAIN, APIDTO>` (APIDTO needs to be target, DOMAIN object needs to be source)
+ */
+@MapperConfig(componentModel = "spring", uses = {ConversionServiceAdapter.class, OptionalMapstructSupport.class}, unmappedSourcePolicy = ReportingPolicy.IGNORE, unmappedTargetPolicy = ReportingPolicy.ERROR)
+public interface DomainFormMapperConfiguration {
+}

--- a/backend/src/main/java/club/klabis/domain/members/Member.java
+++ b/backend/src/main/java/club/klabis/domain/members/Member.java
@@ -1,8 +1,12 @@
 package club.klabis.domain.members;
 
+import club.klabis.api.dto.EditAnotherMemberDetailsFormApiDto;
+import club.klabis.api.dto.EditMyDetailsFormApiDto;
 import club.klabis.domain.members.events.MemberCreatedEvent;
 import club.klabis.domain.members.events.MemberEditedEvent;
 import club.klabis.domain.members.events.MemberWasSuspendedEvent;
+import club.klabis.domain.members.forms.EditAnotherMemberInfoByAdminForm;
+import club.klabis.domain.members.forms.EditOwnMemberInfoForm;
 import club.klabis.domain.members.forms.MemberEditForm;
 import club.klabis.domain.members.forms.RegistrationForm;
 import org.jmolecules.ddd.annotation.AggregateRoot;
@@ -117,6 +121,34 @@ public class Member extends AbstractAggregateRoot<Member> {
         this.andEvent(new MemberEditedEvent(this));
     }
 
+    public void edit(EditOwnMemberInfoForm form) {
+        this.identityCard = form.identityCard();
+        this.nationality = form.nationality();
+        this.address = form.address();
+        this.contact.clear();
+        this.contact.addAll(form.contact());
+        this.legalGuardians.clear();
+        this.legalGuardians.addAll(form.guardians());
+        this.siCard = form.siCard();
+        this.bankAccount = form.bankAccount();
+        this.dietaryRestrictions = form.dietaryRestrictions();
+        this.drivingLicence.clear();
+        this.drivingLicence.addAll(form.drivingLicence());
+        this.medicCourse = form.medicCourse();
+        this.andEvent(new MemberEditedEvent(this));
+    }
+
+    public void edit(EditAnotherMemberInfoByAdminForm form) {
+        this.firstName = form.firstName();
+        this.lastName = form.lastName();
+        this.nationality = form.nationality();
+        this.dateOfBirth = form.dateOfBirth();
+        this.birthCertificateNumber = form.birthCertificateNumber();
+        this.sex = form.sex();
+        this.andEvent(new MemberEditedEvent(this));
+
+    }
+
     public void suspend() {
         if (!this.suspended) {
             this.suspended = true;
@@ -211,4 +243,5 @@ public class Member extends AbstractAggregateRoot<Member> {
     public boolean isSuspended() {
         return suspended;
     }
+
 }

--- a/backend/src/main/java/club/klabis/domain/members/MemberService.java
+++ b/backend/src/main/java/club/klabis/domain/members/MemberService.java
@@ -1,5 +1,8 @@
 package club.klabis.domain.members;
 
+import club.klabis.api.dto.EditMyDetailsFormApiDto;
+import club.klabis.domain.members.forms.EditAnotherMemberInfoByAdminForm;
+import club.klabis.domain.members.forms.EditOwnMemberInfoForm;
 import club.klabis.domain.members.forms.MemberEditForm;
 import club.klabis.domain.members.forms.RegistrationForm;
 import jakarta.validation.Valid;
@@ -21,9 +24,17 @@ public interface MemberService {
 
     RegistrationNumber suggestRegistrationNumber(LocalDate dateOfBirth, Sex sex);
 
-    Member editMember(Integer memberId, @Valid MemberEditForm editForm);
-
     Optional<MembershipSuspensionInfo> getSuspensionInfoForMember(int memberId);
 
     void suspendMembershipForMember(int memberId, boolean forceSuspension);
+
+    Member editMember(Integer memberId, @Valid MemberEditForm editForm);
+
+    EditAnotherMemberInfoByAdminForm getEditAnotherMemberForm(Integer memberId);
+
+    Member editMember(Integer memberId, @Valid EditAnotherMemberInfoByAdminForm form);
+
+    EditOwnMemberInfoForm getEditOwnMemberInfoForm(Integer memberId);
+
+    Member editMember(Integer memberId, @Valid EditOwnMemberInfoForm form);
 }

--- a/backend/src/main/java/club/klabis/domain/members/MemberServiceImpl.java
+++ b/backend/src/main/java/club/klabis/domain/members/MemberServiceImpl.java
@@ -1,7 +1,10 @@
 package club.klabis.domain.members;
 
+import club.klabis.domain.members.forms.EditAnotherMemberInfoByAdminForm;
+import club.klabis.domain.members.forms.EditOwnMemberInfoForm;
 import club.klabis.domain.members.forms.MemberEditForm;
 import club.klabis.domain.members.forms.RegistrationForm;
+import org.springframework.core.convert.ConversionService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,9 +15,11 @@ import java.util.Optional;
 @Service
 class MemberServiceImpl implements MemberService {
     private final MembersRepository membersRepository;
+    private final ConversionService conversionService;
 
-    MemberServiceImpl(MembersRepository membersRepository) {
+    MemberServiceImpl(MembersRepository membersRepository, ConversionService conversionService) {
         this.membersRepository = membersRepository;
+        this.conversionService = conversionService;
     }
 
     @Override
@@ -88,4 +93,39 @@ class MemberServiceImpl implements MemberService {
             throw new MembershipCannotBeSuspendedException(memberId, "member is already suspended");
         }
     }
+
+    @Transactional
+    @Override
+    public Member editMember(Integer memberId, EditOwnMemberInfoForm form) {
+        Member member = membersRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(memberId));
+
+        member.edit(form);
+        return membersRepository.save(member);
+    }
+
+    @Override
+    public EditAnotherMemberInfoByAdminForm getEditAnotherMemberForm(Integer memberId) {
+        return findById(memberId)
+                .map(m -> conversionService.convert(m, EditAnotherMemberInfoByAdminForm.class))
+                .orElseThrow(() -> new MemberNotFoundException(memberId));
+    }
+
+    @Override
+    public Member editMember(Integer memberId, EditAnotherMemberInfoByAdminForm form) {
+        Member member = membersRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(memberId));
+
+        member.edit(form);
+        return membersRepository.save(member);
+    }
+
+    @Override
+    public EditOwnMemberInfoForm getEditOwnMemberInfoForm(Integer memberId) {
+        return findById(memberId)
+                .map(m -> conversionService.convert(m, EditOwnMemberInfoForm.class))
+                .orElseThrow(() -> new MemberNotFoundException(memberId));
+    }
+
+
 }

--- a/backend/src/main/java/club/klabis/domain/members/forms/AtLeastOneContactIsDefined.java
+++ b/backend/src/main/java/club/klabis/domain/members/forms/AtLeastOneContactIsDefined.java
@@ -9,7 +9,8 @@ import java.lang.annotation.*;
 @Constraint(validatedBy = {
         AtLeastOneContactIsDefinedConstraint.MemberEditFormValidator.class,
         AtLeastOneContactIsDefinedConstraint.RegistrationFormValidator.class,
-        AtLeastOneContactIsDefinedConstraint.EditOwnMemberInfoFormValidator.class
+        AtLeastOneContactIsDefinedConstraint.EditOwnMemberInfoFormValidator.class,
+        AtLeastOneContactIsDefinedConstraint.EditMyDetailsFormApiDtoFormValidator.class
 })
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/backend/src/main/java/club/klabis/domain/members/forms/AtLeastOneContactIsDefined.java
+++ b/backend/src/main/java/club/klabis/domain/members/forms/AtLeastOneContactIsDefined.java
@@ -4,27 +4,27 @@ import club.klabis.domain.members.Contact;
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 @Constraint(validatedBy = {
         AtLeastOneContactIsDefinedConstraint.MemberEditFormValidator.class,
-        AtLeastOneContactIsDefinedConstraint.RegistrationFormValidator.class
+        AtLeastOneContactIsDefinedConstraint.RegistrationFormValidator.class,
+        AtLeastOneContactIsDefinedConstraint.EditOwnMemberInfoFormValidator.class
 })
-@Target({ ElementType.TYPE })
+@Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
+@Repeatable(AtLeastOneContactIsDefined.List.class)
 public @interface AtLeastOneContactIsDefined {
 
     String message() default "At least one contact or guardian with contact must be provided";
+
     Class<?>[] groups() default {};
 
     Class<? extends Payload>[] payload() default {};
 
     Contact.Type contactType();
 
-    @Target({ ElementType.TYPE })
+    @Target({ElementType.TYPE})
     @Retention(RetentionPolicy.RUNTIME)
     @interface List {
         AtLeastOneContactIsDefined[] value();

--- a/backend/src/main/java/club/klabis/domain/members/forms/AtLeastOneContactIsDefinedConstraint.java
+++ b/backend/src/main/java/club/klabis/domain/members/forms/AtLeastOneContactIsDefinedConstraint.java
@@ -43,6 +43,21 @@ class AtLeastOneContactIsDefinedConstraint {
 
     }
 
+    static class EditOwnMemberInfoFormValidator implements ConstraintValidator<AtLeastOneContactIsDefined, EditOwnMemberInfoForm> {
+        private AtLeastOneContactIsDefined annotation;
+
+        @Override
+        public void initialize(AtLeastOneContactIsDefined constraintAnnotation) {
+            this.annotation = constraintAnnotation;
+        }
+
+        @Override
+        public boolean isValid(EditOwnMemberInfoForm registrationForm, ConstraintValidatorContext constraintValidatorContext) {
+            return AtLeastOneContactIsDefinedConstraint.isValid(registrationForm.contact(), registrationForm.guardians(), annotation.contactType());
+        }
+
+    }
+
     static class MemberEditFormValidator implements ConstraintValidator<AtLeastOneContactIsDefined, MemberEditForm> {
         private AtLeastOneContactIsDefined annotation;
 

--- a/backend/src/main/java/club/klabis/domain/members/forms/AtLeastOneContactIsDefinedConstraint.java
+++ b/backend/src/main/java/club/klabis/domain/members/forms/AtLeastOneContactIsDefinedConstraint.java
@@ -1,11 +1,17 @@
 package club.klabis.domain.members.forms;
 
+import club.klabis.api.dto.ContactApiDto;
+import club.klabis.api.dto.EditMyDetailsFormApiDto;
+import club.klabis.api.dto.LegalGuardianApiDto;
 import club.klabis.domain.members.Contact;
 import club.klabis.domain.members.LegalGuardian;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Valid;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collection;
+import java.util.List;
 
 class AtLeastOneContactIsDefinedConstraint {
 
@@ -24,9 +30,32 @@ class AtLeastOneContactIsDefinedConstraint {
         return false;
     }
 
+    private static boolean isValid(@Valid ContactApiDto contact, @Valid List<LegalGuardianApiDto> guardians, Contact.Type requiredContactType) {
+        if (hasContactOfType(contact, requiredContactType)) {
+            return true;
+        }
+
+        if (guardians != null) {
+            return guardians.stream().map(LegalGuardianApiDto::getContact).anyMatch(c -> hasContactOfType(c, requiredContactType));
+        }
+
+        return false;
+    }
+
     private static boolean hasContactOfType(Collection<Contact> contacts, Contact.Type contactType) {
         return contacts != null && contacts.stream().anyMatch(c -> contactType.equals(c.type()));
     }
+
+    private static boolean hasContactOfType(ContactApiDto contacts, Contact.Type contactType) {
+        if (contacts == null) {
+            return false;
+        }
+        return switch (contactType) {
+            case EMAIL -> StringUtils.isNotBlank(contacts.getEmail());
+            case PHONE -> StringUtils.isNotBlank(contacts.getPhone());
+        };
+    }
+
 
     static class RegistrationFormValidator implements ConstraintValidator<AtLeastOneContactIsDefined, RegistrationForm> {
         private AtLeastOneContactIsDefined annotation;
@@ -71,6 +100,20 @@ class AtLeastOneContactIsDefinedConstraint {
             return AtLeastOneContactIsDefinedConstraint.isValid(editForm.contact(), editForm.guardians(), annotation.contactType());
         }
 
+    }
+
+    static class EditMyDetailsFormApiDtoFormValidator implements ConstraintValidator<AtLeastOneContactIsDefined, EditMyDetailsFormApiDto> {
+        private AtLeastOneContactIsDefined annotation;
+
+        @Override
+        public void initialize(AtLeastOneContactIsDefined constraintAnnotation) {
+            this.annotation = constraintAnnotation;
+        }
+
+        @Override
+        public boolean isValid(EditMyDetailsFormApiDto editForm, ConstraintValidatorContext constraintValidatorContext) {
+            return AtLeastOneContactIsDefinedConstraint.isValid(editForm.getContact(), editForm.getGuardians(), annotation.contactType());
+        }
     }
 
 }

--- a/backend/src/main/java/club/klabis/domain/members/forms/BirthCertificateIsDefinedForCzechia.java
+++ b/backend/src/main/java/club/klabis/domain/members/forms/BirthCertificateIsDefinedForCzechia.java
@@ -11,7 +11,8 @@ import java.lang.annotation.Target;
 @Constraint(validatedBy = {
         BirthCertificateIsDefinedForCzechiaConstraint.RegistrationFormValidator.class,
         BirthCertificateIsDefinedForCzechiaConstraint.MemberEditFormValidator.class,
-        BirthCertificateIsDefinedForCzechiaConstraint.EditAnotherMemberInfoByAdminFormValidator.class
+        BirthCertificateIsDefinedForCzechiaConstraint.EditAnotherMemberInfoByAdminFormValidator.class,
+        BirthCertificateIsDefinedForCzechiaConstraint.EditAnotherMemberDetailsFormApiDtoValidator.class
 })
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/backend/src/main/java/club/klabis/domain/members/forms/BirthCertificateIsDefinedForCzechia.java
+++ b/backend/src/main/java/club/klabis/domain/members/forms/BirthCertificateIsDefinedForCzechia.java
@@ -10,7 +10,8 @@ import java.lang.annotation.Target;
 
 @Constraint(validatedBy = {
         BirthCertificateIsDefinedForCzechiaConstraint.RegistrationFormValidator.class,
-        BirthCertificateIsDefinedForCzechiaConstraint.MemberEditFormValidator.class
+        BirthCertificateIsDefinedForCzechiaConstraint.MemberEditFormValidator.class,
+        BirthCertificateIsDefinedForCzechiaConstraint.EditAnotherMemberInfoByAdminFormValidator.class
 })
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/backend/src/main/java/club/klabis/domain/members/forms/BirthCertificateIsDefinedForCzechiaConstraint.java
+++ b/backend/src/main/java/club/klabis/domain/members/forms/BirthCertificateIsDefinedForCzechiaConstraint.java
@@ -1,5 +1,6 @@
 package club.klabis.domain.members.forms;
 
+import club.klabis.api.dto.EditAnotherMemberDetailsFormApiDto;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import org.springframework.util.StringUtils;
@@ -34,6 +35,14 @@ class BirthCertificateIsDefinedForCzechiaConstraint {
         @Override
         public boolean isValid(EditAnotherMemberInfoByAdminForm memberEditForm, ConstraintValidatorContext constraintValidatorContext) {
             return BirthCertificateIsDefinedForCzechiaConstraint.isValid(memberEditForm.nationality(), memberEditForm.birthCertificateNumber());
+        }
+    }
+
+    static class EditAnotherMemberDetailsFormApiDtoValidator implements ConstraintValidator<BirthCertificateIsDefinedForCzechia, EditAnotherMemberDetailsFormApiDto> {
+
+        @Override
+        public boolean isValid(EditAnotherMemberDetailsFormApiDto editAnotherMemberDetailsFormApiDto, ConstraintValidatorContext constraintValidatorContext) {
+            return BirthCertificateIsDefinedForCzechiaConstraint.isValid(editAnotherMemberDetailsFormApiDto.getNationality(), editAnotherMemberDetailsFormApiDto.getBirthCertificateNumber());
         }
     }
 }

--- a/backend/src/main/java/club/klabis/domain/members/forms/BirthCertificateIsDefinedForCzechiaConstraint.java
+++ b/backend/src/main/java/club/klabis/domain/members/forms/BirthCertificateIsDefinedForCzechiaConstraint.java
@@ -29,4 +29,11 @@ class BirthCertificateIsDefinedForCzechiaConstraint {
             return BirthCertificateIsDefinedForCzechiaConstraint.isValid(memberEditForm.nationality(), memberEditForm.birthCertificateNumber());
         }
     }
+
+    static class EditAnotherMemberInfoByAdminFormValidator implements ConstraintValidator<BirthCertificateIsDefinedForCzechia, EditAnotherMemberInfoByAdminForm> {
+        @Override
+        public boolean isValid(EditAnotherMemberInfoByAdminForm memberEditForm, ConstraintValidatorContext constraintValidatorContext) {
+            return BirthCertificateIsDefinedForCzechiaConstraint.isValid(memberEditForm.nationality(), memberEditForm.birthCertificateNumber());
+        }
+    }
 }

--- a/backend/src/main/java/club/klabis/domain/members/forms/EditAnotherMemberInfoByAdminForm.java
+++ b/backend/src/main/java/club/klabis/domain/members/forms/EditAnotherMemberInfoByAdminForm.java
@@ -1,0 +1,24 @@
+package club.klabis.domain.members.forms;
+
+import club.klabis.domain.members.Sex;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+@BirthCertificateIsDefinedForCzechia
+public record EditAnotherMemberInfoByAdminForm(
+        @NotBlank
+        String firstName,
+        @NotBlank
+        String lastName,
+        @NotNull
+        LocalDate dateOfBirth,
+        String birthCertificateNumber,
+        @NotBlank
+        String nationality,
+        @NotNull
+        Sex sex
+) {
+
+}

--- a/backend/src/main/java/club/klabis/domain/members/forms/EditOwnMemberInfoForm.java
+++ b/backend/src/main/java/club/klabis/domain/members/forms/EditOwnMemberInfoForm.java
@@ -1,0 +1,25 @@
+package club.klabis.domain.members.forms;
+
+import club.klabis.domain.members.*;
+import jakarta.validation.Valid;
+
+import java.util.Collection;
+import java.util.List;
+
+@AtLeastOneContactIsDefined(contactType = Contact.Type.EMAIL, message = "At least one email contact must be provided")
+@AtLeastOneContactIsDefined(contactType = Contact.Type.PHONE, message = "At least one phone contact must be provided")
+public record EditOwnMemberInfoForm(
+        IdentityCard identityCard,
+        String nationality,
+        Address address,
+        Collection<Contact> contact,
+        @Valid
+        List<@Valid LegalGuardian> guardians,
+        String siCard,
+        String bankAccount,
+        String dietaryRestrictions,
+        @Valid
+        List<@Valid DrivingLicence> drivingLicence,
+        Boolean medicCourse
+) {
+}

--- a/backend/src/main/java/club/klabis/domain/members/forms/MemberEditForm.java
+++ b/backend/src/main/java/club/klabis/domain/members/forms/MemberEditForm.java
@@ -8,10 +8,8 @@ import java.time.LocalDate;
 import java.util.Collection;
 
 @BirthCertificateIsDefinedForCzechia
-@AtLeastOneContactIsDefined.List({
-        @AtLeastOneContactIsDefined(contactType = Contact.Type.EMAIL, message = "At least one email contact must be provided"),
-        @AtLeastOneContactIsDefined(contactType = Contact.Type.PHONE, message = "At least one phone contact must be provided")
-})
+@AtLeastOneContactIsDefined(contactType = Contact.Type.EMAIL, message = "At least one email contact must be provided")
+@AtLeastOneContactIsDefined(contactType = Contact.Type.PHONE, message = "At least one phone contact must be provided")
 public record MemberEditForm(
         @NotBlank
         String firstName,

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -232,3 +232,4 @@ server:
     key-store-type: PKCS12
     key-alias: klabisSSL
   port: 8443
+

--- a/backend/src/main/resources/presetData/members.csv
+++ b/backend/src/main/resources/presetData/members.csv
@@ -1,6 +1,6 @@
 firstName,lastName,registrationNumber,sex,dateOfBirth,birthCertificateNumber,nationality,street,city,postalCode,country,email,phone,siCard,bankAccount,orisId,googleId
-David,Polách,ZBM8003,male,1980-04-26,1234567890,CZ,Nekde 12,Brno,63000,CZ,test@test.com,999999999,,,,110875617296914468258
-Otakar,Hirš,ZBM9801,male,1998-01-01,1234567890,CZ,Jinde 1,Brno,63600,CZ,ota@ota.cz,999999999,,,,103575135673576139314
-Luděk,Finstrle,ZBM7902,male,1979-01-01,1234567890,CZ,,,,,luf@email.cz,999999999,,,,
-Aleš,Finstrle,ZBM7603,male,1976-01-01,1234567890,CZ,,,,,alf@email.cz,999999999,,,,
-Pavel,Rotek,ZBM7704,male,1977-01-01,1234567890,CZ,,,,,pavel@gmail.com,999999999,,,,
+David,Polách,ZBM8003,male,1980-04-26,123456/7890,CZ,Nekde 12,Brno,63000,CZ,test@test.com,999999999,,,,110875617296914468258
+Otakar,Hirš,ZBM9801,male,1998-01-01,123456/7890,CZ,Jinde 1,Brno,63600,CZ,ota@ota.cz,999999999,,,,103575135673576139314
+Luděk,Finstrle,ZBM7902,male,1979-01-01,123456/7890,CZ,,,,,luf@email.cz,999999999,,,,
+Aleš,Finstrle,ZBM7603,male,1976-01-01,123456/7890,CZ,,,,,alf@email.cz,999999999,,,,
+Pavel,Rotek,ZBM7704,male,1977-01-01,123456/7890,CZ,,,,,pavel@gmail.com,999999999,,,,

--- a/klabis-api-spec.yaml
+++ b/klabis-api-spec.yaml
@@ -150,6 +150,7 @@ paths:
       tags:
         - members
         - BFF
+      deprecated: true
       summary: "Returns data for edit member information form"
       responses:
         '200':
@@ -172,12 +173,118 @@ paths:
       tags:
         - members
       summary: "Update member information"
+      deprecated: true
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/MemberEditForm'
+      responses:
+        '200':
+          description: Club member updated successfully
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+          description: Forbidden - User does not have permission to update a member
+        '404':
+          $ref: '#/components/responses/401'
+          description: Club member not found
+
+  /members/{memberId}/editByAdminForm:
+    parameters:
+      - $ref: '#/components/parameters/MemberIdPath'
+    get:
+      tags:
+        - members
+        - BFF
+      operationId: getMemberEditByAdminForm
+      summary: "Returns data for edit member information form"
+      description: |-
+        Returns data for edit member information form
+        
+        #### Required authorization
+        requires `members:suspendMembership` grant
+      responses:
+        '200':
+          description: Club member updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EditAnotherMemberDetailsForm'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+          description: Forbidden - User does not have permission to update a member
+        '404':
+          $ref: '#/components/responses/401'
+          description: Club member not found
+    put:
+      tags:
+        - members
+      summary: "Update member information"
+      operationId: putMemberEditByAdminForm
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EditAnotherMemberDetailsForm'
+      responses:
+        '200':
+          description: Club member updated successfully
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+          description: Forbidden - User does not have permission to update a member
+        '404':
+          $ref: '#/components/responses/401'
+          description: Club member not found
+
+  /members/{memberId}/editOwnMemberInfoForm:
+    parameters:
+      - $ref: '#/components/parameters/MemberIdPath'
+    get:
+      tags:
+        - members
+        - BFF
+      summary: "Returns data for edit member information form"
+      responses:
+        '200':
+          description: Club member updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EditMyDetailsForm'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+          description: Forbidden - User does not have permission to update a member
+        '404':
+          $ref: '#/components/responses/401'
+          description: Club member not found
+    put:
+      tags:
+        - members
+      summary: "Update member information"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EditMyDetailsForm'
       responses:
         '200':
           description: Club member updated successfully
@@ -217,7 +324,7 @@ paths:
         '404':
           $ref: '#/components/responses/401'
           description: Club member not found
-    post:
+    put:
       tags:
         - members
       summary: Suspend membership for a club member
@@ -331,7 +438,7 @@ paths:
           $ref: '#/components/responses/401'
 
   /memberRegistrations:
-    post:
+    put:
       tags:
         - members
       summary: Register a new club member
@@ -682,9 +789,9 @@ components:
           $ref: '#/components/schemas/RegistrationNumber'
         orisId:
           $ref: '#/components/schemas/OrisID'
-#        trainingGroup:
-#          type: ???
-#          description: training group where newly registered member will be added
+    #        trainingGroup:
+    #          type: ???
+    #          description: training group where newly registered member will be added
     EditAnotherMemberDetailsForm:
       type: object
       description: |-
@@ -692,7 +799,7 @@ components:
 
         #### Required authorization
         - requires `members:edit` grant
-       
+        
         Additional validations: 
         - when `CZ` is selected as nationality, then `birthCertificateNumber` is required value
       required:
@@ -869,6 +976,7 @@ components:
         | `members:register` | can create new members |
         | `members:edit` | can edit selected attributes for all existing members |
         | `members:suspendMembership` | can suspend membership for club members |
+        | `members:permissions` | can change global grants for any member |
       enum:
         - members:register
         - members:edit

--- a/klabis-api-spec.yaml
+++ b/klabis-api-spec.yaml
@@ -802,6 +802,7 @@ components:
         
         Additional validations: 
         - when `CZ` is selected as nationality, then `birthCertificateNumber` is required value
+      x-class-extra-annotation: "@club.klabis.domain.members.forms.BirthCertificateIsDefinedForCzechia"
       required:
         - firstName
         - lastName
@@ -834,6 +835,11 @@ components:
 
         Additional validations:
         - either contact or at least 1 guardian needs to be entered
+      x-class-extra-annotation: |-
+        @club.klabis.domain.members.forms.AtLeastOneContactIsDefined.List({
+          @club.klabis.domain.members.forms.AtLeastOneContactIsDefined(contactType = club.klabis.domain.members.Contact.Type.EMAIL, message = "At least one email contact must be provided"),
+          @club.klabis.domain.members.forms.AtLeastOneContactIsDefined(contactType = club.klabis.domain.members.Contact.Type.PHONE, message = "At least one phone contact must be provided")
+        })
       required:
         - nationality
         - address


### PR DESCRIPTION
- member edit form split into two: 
     - `{{host}}/members/1/editOwnMemberInfoForm`  => form for members to edit own info
     - `{{host}}/members/1/editByAdminForm` => form for admins to edit info about other members
- several bugfixes:
     - initial data loaded in "db" have correct format of birthday certificate number
     - ORIS proxy API doesn't respond with HTTP 500 when user is not found by reg num
     - advanced validations (birthday certificate number for CZ, at least one email/phone contact) doesn't respond with HTTP 500 