### PR TITLE
feat(hateoas): wrap plain payload DTOs into HAL models via ResponseBodyAdvice

### DIFF
--- a/.claude/skills/backend-patterns/SKILL.md
+++ b/.claude/skills/backend-patterns/SKILL.md
@@ -2,7 +2,7 @@
 name: backend-patterns
 description: Backend implementation patterns. Use this skill proactively whenever implementing, modifying, or fixing any backend Java code in this project — including aggregates, domain commands, application services (ports), REST controllers with HATEOAS affordances (klabisLinkTo/klabisAfford), JDBC persistence (memento pattern, repository adapters), domain events and listeners, field-level authorization (@OwnerVisible, @HasAuthority, PatchField), or adding new modules. This is the authoritative source for how Klabis backend code should be structured.
 user-invocable: false
-version: 0.5.1
+version: 0.6.0
 ---
 
 # Klabis Backend Patterns
@@ -242,23 +242,43 @@ ResponseEntity<Void> updateMember(@PathVariable @OwnerId UUID id,
 
 Field-level authorization on request DTO (`@HasAuthority`, `@OwnerVisible` on `PatchField<T>` components) is enforced by `RequestBodyFieldAuthorizationAdvice`. Single command path — no role-based branching in controller.
 
-### HATEOAS — EntityModelWithDomain + Postprocessor Pattern
+### HATEOAS — Controllers Return Plain DTOs; HalResponseBodyAdvice Wraps Them
 
-**Primary choice for creating `EntityModel` instances in controllers that load a domain aggregate.** Controllers focus on returning data; all link/affordance customization lives in a dedicated postprocessor that receives BOTH the DTO-shaped `EntityModel<T>` and the domain aggregate `D`.
+**Canonical pattern for all new/migrated controllers.** Since the migration to spec-first OpenAPI generation, controller methods must return the plain JSON-payload type from the generated API interface (`ResponseEntity<SomeResponse>` / `ResponseEntity<Page<SomeResponse>>`) — the generator does not produce `EntityModel`/`PagedModel` return types. Hypermedia wrapping happens **after** the controller returns, via `HalResponseBodyAdvice` (a `ResponseBodyAdvice` in `com.klabis.common.ui`), driven by a request-scoped `HalResponseContext` that the controller populates with the domain object(s) behind the DTO.
 
-**Controller — use `entityModelWithDomain(dto, domain)` instead of `EntityModel.of(dto)`:**
+**Controller — return the plain DTO, stash the domain object(s) in `HalResponseContext` before returning:**
 
 ```java
 @GetMapping("/{id}")
-ResponseEntity<EntityModel<MemberDetailsResponse>> getMember(@PathVariable UUID id) {
-    Member member = managementService.getMember(new MemberId(id));
-    return ResponseEntity.ok(entityModelWithDomain(memberMapper.toDetailsResponse(member), member));
+ResponseEntity<MemberDetailsResponse> getMember(@PathVariable UUID id, @ActingUser CurrentUserData currentUser) {
+    Member member = managementService.getMemberAndRecordView(new MemberId(id), currentUser.userId(), ...);
+
+    HalResponseContext.setDomain(member);          // must run after everything that can throw
+    return ResponseEntity.ok(memberMapper.toDetailsResponse(member));
 }
 ```
 
-The controller does NOT add links/affordances inline. It just wraps the DTO with the domain aggregate and returns. `EntityModelWithDomain<T, D>` is a subclass of `EntityModel<T>` that piggy-backs the domain object; the domain is `@JsonIgnore`-annotated so it never leaks into the response body.
+For a paginated collection, use `setDomainList` — same order as the DTO `Page` content, paired 1:1 by index:
 
-**Postprocessor — extend `ModelWithDomainPostprocessor<T, D>`:**
+```java
+@GetMapping
+ResponseEntity<Page<MemberSummaryResponse>> listMembers(@ParameterObject Pageable pageable, ...) {
+    Page<Member> memberPage = memberRepository.findAll(filter, pageable);
+
+    HalResponseContext.setDomainList(memberPage.getContent());
+    return ResponseEntity.ok(memberPage.map(memberMapper::toSummaryResponse));
+}
+```
+
+**Always call `HalResponseContext.set*` last, after any code that can throw.** If the controller throws afterwards, `MvcExceptionHandler` returns a `ProblemDetail`; `HalResponseBodyAdvice` detects that and clears the context instead of wrapping the error body, but only if nothing between `set*` and the exception can leave stale context data for a *different* concern.
+
+**What the advice does, automatically, with no controller involvement:**
+- Single DTO → wraps it in `EntityModelWithDomain<T, D>` and runs it through every `RepresentationModelProcessor` bean — including `ModelWithDomainPostprocessor<Dto, Aggregate>` postprocessors.
+- `Page<Dto>` → runs it through `PagedResourcesAssembler`, pairing each DTO with its domain object via `HalResponseContext`'s stashed list, then derives the **self link directly from the current request's path and query parameters** (no `klabisLinkTo` call needed for the self link — the controller method already ran and passed authorization for exactly this request).
+- Non-HAL content types (e.g. `MemberOptionResponse` served as plain `application/json`) are left untouched — the advice checks `selectedContentType` and only wraps `HAL_JSON`/`HAL_FORMS_JSON` responses.
+- A `ProblemDetail` error body is never wrapped, and the context is cleared so nothing leaks into a later request on the same thread pool.
+
+**Postprocessor — extend `ModelWithDomainPostprocessor<T, D>`, which receives the DTO-shaped `EntityModel<T>` and the domain aggregate `D`:**
 
 ```java
 @MvcComponent
@@ -266,7 +286,7 @@ class MemberDetailsPostprocessor extends ModelWithDomainPostprocessor<MemberDeta
 
     @Override
     public void process(EntityModel<MemberDetailsResponse> dtoModel, Member member) {
-        klabisLinkTo(methodOn(MemberController.class).getMember(member.getId().uuid()))
+        klabisLinkTo(methodOn(MemberController.class).getMember(member.getId().uuid(), null))
             .map(link -> {
                 var self = link.withSelfRel()
                     .andAffordances(klabisAfford(methodOn(MemberController.class).updateMember(member.getId().uuid(), null, null)));
@@ -282,18 +302,27 @@ class MemberDetailsPostprocessor extends ModelWithDomainPostprocessor<MemberDeta
 }
 ```
 
-**Why this pattern:**
-- State-driven affordances read from the real aggregate (`member.isActive()`) — no reliance on whether the DTO field has already been filtered by Jackson field-level security.
-- Controllers stay small; all hypermedia shaping is externalized. Multiple postprocessors can compose for the same endpoint (e.g. cross-module concerns: a training-groups postprocessor adding a `trainingGroup` link to member details).
-- Cross-module postprocessors live in the consuming module — they declare their dependency on the DTO+domain pair explicitly via generics.
-- `domainItem` is `@JsonIgnore` — safe from serialization.
+**Collection-level affordances (not per item) go on the `PagedModel` itself**, in a plain `RepresentationModelProcessor<PagedModel<EntityModel<Dto>>>` — the self link already exists (built by the advice), this processor only adds affordances that point at *other* endpoints:
 
-**Fallback — plain `EntityModel.of(dto)`:** acceptable only when there is no domain aggregate in scope (e.g., pure DTO projections, synthetic summaries, `RootModel` navigation). For standard aggregate-backed endpoints use the postprocessor pattern.
-
-**Static import:**
 ```java
-import static com.klabis.common.ui.HalFormsSupport.entityModelWithDomain;
+@MvcComponent
+class MemberListPostprocessor implements RepresentationModelProcessor<PagedModel<EntityModel<MemberSummaryResponse>>> {
+
+    @Override
+    public PagedModel<EntityModel<MemberSummaryResponse>> process(PagedModel<EntityModel<MemberSummaryResponse>> pagedModel) {
+        pagedModel.mapLink(IanaLinkRelations.SELF, selfLink -> (Link) selfLink
+                .andAffordances(klabisAfford(methodOn(MemberController.class).updateMember(null, null, null)))
+                .andAffordances(klabisAfford(methodOn(RegistrationController.class).registerMember(null, null))));
+        return pagedModel;
+    }
+}
 ```
+
+**Why this pattern:**
+- Controllers return the exact type the OpenAPI-generated API interface requires — no `EntityModel`/`PagedModel` in the method signature, so the generated interface can be implemented directly once that migration lands for a module.
+- State-driven affordances still read from the real aggregate (`member.isActive()`) — the postprocessor pipeline is unchanged, only how it gets invoked (advice vs. HATEOAS's own `HandlerMethodReturnValueHandler`, which only fires for return values that are already a `RepresentationModel`).
+- The self link for a collection no longer needs a `klabisLinkTo(methodOn(...).listMembers(pageable, q, status, null))` call re-deriving the current request in the controller — it's built once, generically, by the advice for every paginated endpoint.
+- Non-aggregate-backed responses (pure projections like `MemberOptionResponse`, served as plain JSON) are naturally skipped — no `HalResponseContext` entry means the advice passes the body through unchanged.
 
 ### HATEOAS Rules (NON-NEGOTIABLE)
 
@@ -326,7 +355,8 @@ Same HATEOAS rules apply — no affordances to POST endpoints.
 
 | Situation | Use |
 |---|---|
-| Controller loads an aggregate and returns its detail/summary | `ModelWithDomainPostprocessor<Dto, Aggregate>` — controller returns `entityModelWithDomain(dto, aggregate)` |
+| Controller loads an aggregate and returns its detail/summary | `ModelWithDomainPostprocessor<Dto, Aggregate>` — controller calls `HalResponseContext.setDomain(aggregate)` before returning the plain DTO |
+| Collection-level affordances to other endpoints | Plain `RepresentationModelProcessor<PagedModel<EntityModel<Dto>>>` — the self link itself is built by `HalResponseBodyAdvice`; this processor only adds affordances |
 | Root navigation (`RootModel`) | Plain `RepresentationModelProcessor<EntityModel<RootModel>>` — no domain involved |
 | Cross-module link enrichment where consuming module knows only the DTO's marker interface and the publishing controller does not expose the aggregate | Plain `RepresentationModelProcessor<EntityModel<MarkerInterface>>` |
 
@@ -512,15 +542,14 @@ record MemberDetailResponse(
 ) {}
 ```
 
-Controller returns a plain record — no proxy call needed:
+Controller returns a plain record — no proxy call needed. Field security applies during Jackson serialization regardless of when in the response pipeline the DTO gets wrapped into `EntityModel` (see the HATEOAS section above):
 
 ```java
 @GetMapping("/{id}")
-EntityModel<MemberDetailResponse> getMember(@PathVariable UUID id) {
-    MemberDetailResponse response = memberMapper.toDetailResponse(member);
-    return EntityModel.of(response)
-        .add(klabisLinkTo(methodOn(MemberController.class).getMember(id)).withSelfRel()
-            .andAffordances(klabisAfford(methodOn(MemberController.class).updateMember(id, null, null))));
+ResponseEntity<MemberDetailResponse> getMember(@PathVariable UUID id) {
+    Member member = managementService.getMember(new MemberId(id));
+    HalResponseContext.setDomain(member);
+    return ResponseEntity.ok(memberMapper.toDetailResponse(member));
 }
 ```
 

--- a/backend/src/main/java/com/klabis/common/ui/HalResponseBodyAdvice.java
+++ b/backend/src/main/java/com/klabis/common/ui/HalResponseBodyAdvice.java
@@ -1,12 +1,14 @@
 package com.klabis.common.ui;
 
 import com.klabis.common.mvc.MvcComponent;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.IanaLinkRelations;
 import org.springframework.hateoas.Link;
+import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.hateoas.RepresentationModel;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
@@ -17,11 +19,17 @@ import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.function.Supplier;
+import java.util.TreeMap;
 
 /**
  * Bridges plain payload DTOs (as required by the generated OpenAPI-spec API interfaces) back into
@@ -68,10 +76,20 @@ public class HalResponseBodyAdvice implements ResponseBodyAdvice<Object> {
             HalResponseContext.clear();
             return body;
         }
+        if (!isHalMediaType(selectedContentType)) {
+            HalResponseContext.clear();
+            return body;
+        }
         if (body instanceof Page<?> page) {
             return wrapPage(page);
         }
         return wrapSingle(body);
+    }
+
+    private static boolean isHalMediaType(MediaType selectedContentType) {
+        return selectedContentType != null
+               && (MediaTypes.HAL_JSON.isCompatibleWith(selectedContentType)
+                   || MediaTypes.HAL_FORMS_JSON.isCompatibleWith(selectedContentType));
     }
 
     private Object wrapSingle(Object body) {
@@ -107,12 +125,42 @@ public class HalResponseBodyAdvice implements ResponseBodyAdvice<Object> {
         PagedModel<EntityModel<Object>> pagedModel = pagedResourcesAssembler.toModel(objectPage,
                 dto -> HalFormsSupport.entityModelWithDomain(dto, domainIterator.next()));
 
-        Supplier<Optional<Link>> selfLinkSupplier = HalResponseContext.takeSelfLinkSupplier();
-        if (selfLinkSupplier != null) {
-            selfLinkSupplier.get().ifPresent(selfLink ->
-                    pagedModel.mapLink(IanaLinkRelations.SELF, oldLink -> selfLink));
-        }
+        // The controller method already ran (and passed authorization) for the exact request
+        // parameters below, so re-deriving the self link from them needs no separate authorization
+        // check — unlike affordances to *other* endpoints, which still go through klabisAfford in
+        // a postprocessor. PagedResourcesAssembler always adds a self link, so mapLink always finds
+        // one to replace here.
+        currentServletRequest().ifPresent(servletRequest -> {
+            Link selfLink = Link.of(buildSelfLinkUri(servletRequest), IanaLinkRelations.SELF);
+            pagedModel.mapLink(IanaLinkRelations.SELF, oldLink -> selfLink);
+        });
 
         return new RepresentationModelProcessorInvoker(processors).invokeProcessorsFor(pagedModel);
+    }
+
+    /**
+     * Built from {@code getParameterMap()} rather than {@code getQueryString()}: the latter is
+     * {@code null} for {@code MockHttpServletRequest} built via {@code MockMvcRequestBuilders.param(...)}
+     * (as opposed to a literal {@code ?query} in the request URL) — a MockMvc-only gap, but the
+     * parameter map works identically for both real servlet requests and MockMvc ones.
+     * <p>
+     * {@code getRequestURI()} returns the raw (percent-encoded) path while {@code getParameterMap()}
+     * returns decoded values — decoding the path first lets a single {@code UriComponentsBuilder.encode()}
+     * apply consistently to both, instead of double-encoding the path or leaving parameter values
+     * (which may themselves contain {@code &}, {@code =}, {@code +}, {@code #}) unescaped in the query.
+     */
+    private static String buildSelfLinkUri(HttpServletRequest servletRequest) {
+        String decodedPath = UriUtils.decode(servletRequest.getRequestURI(), StandardCharsets.UTF_8);
+        UriComponentsBuilder builder = UriComponentsBuilder.fromPath(decodedPath);
+        Map<String, String[]> sortedParams = new TreeMap<>(servletRequest.getParameterMap());
+        sortedParams.forEach(builder::queryParam);
+        return builder.build().encode().toUriString();
+    }
+
+    private static Optional<HttpServletRequest> currentServletRequest() {
+        if (!(RequestContextHolder.getRequestAttributes() instanceof ServletRequestAttributes attributes)) {
+            return Optional.empty();
+        }
+        return Optional.of(attributes.getRequest());
     }
 }

--- a/backend/src/main/java/com/klabis/common/ui/HalResponseBodyAdvice.java
+++ b/backend/src/main/java/com/klabis/common/ui/HalResponseBodyAdvice.java
@@ -1,0 +1,118 @@
+package com.klabis.common.ui;
+
+import com.klabis.common.mvc.MvcComponent;
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.IanaLinkRelations;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.PagedModel;
+import org.springframework.hateoas.RepresentationModel;
+import org.springframework.hateoas.server.RepresentationModelProcessor;
+import org.springframework.hateoas.server.mvc.RepresentationModelProcessorInvoker;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Bridges plain payload DTOs (as required by the generated OpenAPI-spec API interfaces) back into
+ * the existing HAL postprocessor pipeline.
+ * <p>
+ * A controller stores its domain object(s) in {@link HalResponseContext} before returning a plain
+ * DTO (or a {@link Page} of DTOs). This advice picks the domain back up, wraps the payload in
+ * {@link EntityModelWithDomain} (or a {@link PagedModel} of the same), and manually runs it through
+ * a {@link RepresentationModelProcessorInvoker} built from all {@link RepresentationModelProcessor}
+ * beans — the same postprocessors {@code ModelWithDomainPostprocessor} subclasses already implement.
+ * <p>
+ * Runs strictly after Spring HATEOAS's own {@code RepresentationModelProcessorHandlerMethodReturnValueHandler},
+ * which only recognizes return values that are already a {@link RepresentationModel}. A plain DTO
+ * never satisfies that check, so postprocessing is skipped there entirely — this advice is what
+ * makes postprocessing happen for endpoints that return plain payloads. Controllers that still
+ * build their own {@code EntityModel}/{@code PagedModel} in the old style are untouched: without an
+ * entry in {@link HalResponseContext}, this advice passes the body through unchanged.
+ */
+@MvcComponent
+@ControllerAdvice
+public class HalResponseBodyAdvice implements ResponseBodyAdvice<Object> {
+
+    private final List<RepresentationModelProcessor<?>> processors;
+    private final PagedResourcesAssembler<Object> pagedResourcesAssembler;
+
+    public HalResponseBodyAdvice(List<RepresentationModelProcessor<?>> processors,
+                                  PagedResourcesAssembler<Object> pagedResourcesAssembler) {
+        this.processors = processors;
+        this.pagedResourcesAssembler = pagedResourcesAssembler;
+    }
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
+                                   Class<? extends HttpMessageConverter<?>> selectedConverterType,
+                                   ServerHttpRequest request, ServerHttpResponse response) {
+        // An error path (ProblemDetail) may run after a controller already stored its domain object,
+        // so the context is cleared unconditionally and the error body passed through untouched.
+        if (body instanceof ProblemDetail) {
+            HalResponseContext.clear();
+            return body;
+        }
+        if (body instanceof Page<?> page) {
+            return wrapPage(page);
+        }
+        return wrapSingle(body);
+    }
+
+    private Object wrapSingle(Object body) {
+        Object domain = HalResponseContext.takeDomain();
+        if (domain == null || body instanceof RepresentationModel<?>) {
+            return body;
+        }
+
+        EntityModel<Object> model = HalFormsSupport.entityModelWithDomain(body, domain);
+        return new RepresentationModelProcessorInvoker(processors).invokeProcessorsFor(model);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object wrapPage(Page<?> dtoPage) {
+        List<?> domainList = HalResponseContext.takeDomainList();
+        if (domainList == null) {
+            return dtoPage;
+        }
+
+        List<?> dtoContent = dtoPage.getContent();
+        if (dtoContent.size() != domainList.size()) {
+            throw new IllegalStateException(
+                    "HAL response advice: DTO page content (%d items) and domain list (%d items) must pair 1:1"
+                            .formatted(dtoContent.size(), domainList.size()));
+        }
+
+        Page<Object> objectPage = (Page<Object>) dtoPage;
+        var domainIterator = domainList.iterator();
+
+        // Plain entityModelWithDomain here, without invoking processors yet — invokeProcessorsFor(pagedModel)
+        // below already recurses into each item exactly once (Spring HATEOAS's own CollectionModel handling).
+        // Invoking processors here too would run them twice per item (duplicate self links, affordances, ...).
+        PagedModel<EntityModel<Object>> pagedModel = pagedResourcesAssembler.toModel(objectPage,
+                dto -> HalFormsSupport.entityModelWithDomain(dto, domainIterator.next()));
+
+        Supplier<Optional<Link>> selfLinkSupplier = HalResponseContext.takeSelfLinkSupplier();
+        if (selfLinkSupplier != null) {
+            selfLinkSupplier.get().ifPresent(selfLink ->
+                    pagedModel.mapLink(IanaLinkRelations.SELF, oldLink -> selfLink));
+        }
+
+        return new RepresentationModelProcessorInvoker(processors).invokeProcessorsFor(pagedModel);
+    }
+}

--- a/backend/src/main/java/com/klabis/common/ui/HalResponseContext.java
+++ b/backend/src/main/java/com/klabis/common/ui/HalResponseContext.java
@@ -1,12 +1,9 @@
 package com.klabis.common.ui;
 
-import org.springframework.hateoas.Link;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.util.List;
-import java.util.Optional;
-import java.util.function.Supplier;
 
 /**
  * Carries the domain object(s) behind a plain payload DTO returned by a controller method,
@@ -21,7 +18,6 @@ public final class HalResponseContext {
 
     private static final String SINGLE_DOMAIN_ATTR = HalResponseContext.class.getName() + ".singleDomain";
     private static final String DOMAIN_LIST_ATTR = HalResponseContext.class.getName() + ".domainList";
-    private static final String SELF_LINK_SUPPLIER_ATTR = HalResponseContext.class.getName() + ".selfLinkSupplier";
 
     private HalResponseContext() {
     }
@@ -51,29 +47,9 @@ public final class HalResponseContext {
         return (List<D>) takeAttribute(DOMAIN_LIST_ATTR);
     }
 
-    /**
-     * Registers a supplier for the collection-level self link (e.g. one that re-encodes the
-     * request's query/pagination parameters via {@code klabisLinkTo(methodOn(...))}), applied by
-     * the advice once the {@code PagedModel} exists.
-     * <p>
-     * {@code klabisLinkTo} returns {@link Optional#empty()} when the caller isn't authorized for
-     * the linked method — the supplier must propagate that as {@code Optional.empty()}, not
-     * {@code null}, so the advice can leave the assembler-provided self link untouched instead of
-     * overwriting it with a link built from a null-producing mapper.
-     */
-    public static void setSelfLinkSupplier(Supplier<Optional<Link>> selfLinkSupplier) {
-        setAttribute(SELF_LINK_SUPPLIER_ATTR, selfLinkSupplier);
-    }
-
-    @SuppressWarnings("unchecked")
-    static Supplier<Optional<Link>> takeSelfLinkSupplier() {
-        return (Supplier<Optional<Link>>) takeAttribute(SELF_LINK_SUPPLIER_ATTR);
-    }
-
     static void clear() {
         takeAttribute(SINGLE_DOMAIN_ATTR);
         takeAttribute(DOMAIN_LIST_ATTR);
-        takeAttribute(SELF_LINK_SUPPLIER_ATTR);
     }
 
     private static void setAttribute(String name, Object value) {

--- a/backend/src/main/java/com/klabis/common/ui/HalResponseContext.java
+++ b/backend/src/main/java/com/klabis/common/ui/HalResponseContext.java
@@ -1,0 +1,99 @@
+package com.klabis.common.ui;
+
+import org.springframework.hateoas.Link;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Carries the domain object(s) behind a plain payload DTO returned by a controller method,
+ * so {@link HalResponseBodyAdvice} can re-attach them to build {@code EntityModelWithDomain}
+ * and run the existing {@code RepresentationModelProcessor} postprocessors.
+ * <p>
+ * Scoped to the current HTTP request via a request attribute (same mechanism as
+ * {@link HalFormsSupport}'s inline-option context) — nothing survives past the request,
+ * and nothing leaks between concurrent requests.
+ */
+public final class HalResponseContext {
+
+    private static final String SINGLE_DOMAIN_ATTR = HalResponseContext.class.getName() + ".singleDomain";
+    private static final String DOMAIN_LIST_ATTR = HalResponseContext.class.getName() + ".domainList";
+    private static final String SELF_LINK_SUPPLIER_ATTR = HalResponseContext.class.getName() + ".selfLinkSupplier";
+
+    private HalResponseContext() {
+    }
+
+    /**
+     * Registers the domain object backing a single-item response (e.g. {@code getMember}).
+     */
+    public static <D> void setDomain(D domain) {
+        setAttribute(SINGLE_DOMAIN_ATTR, domain);
+    }
+
+    /**
+     * Registers the domain objects backing a collection response, in the same order as the
+     * DTO list returned by the controller — the advice pairs them 1:1 by index.
+     */
+    public static <D> void setDomainList(List<D> domainList) {
+        setAttribute(DOMAIN_LIST_ATTR, domainList);
+    }
+
+    @SuppressWarnings("unchecked")
+    static <D> D takeDomain() {
+        return (D) takeAttribute(SINGLE_DOMAIN_ATTR);
+    }
+
+    @SuppressWarnings("unchecked")
+    static <D> List<D> takeDomainList() {
+        return (List<D>) takeAttribute(DOMAIN_LIST_ATTR);
+    }
+
+    /**
+     * Registers a supplier for the collection-level self link (e.g. one that re-encodes the
+     * request's query/pagination parameters via {@code klabisLinkTo(methodOn(...))}), applied by
+     * the advice once the {@code PagedModel} exists.
+     * <p>
+     * {@code klabisLinkTo} returns {@link Optional#empty()} when the caller isn't authorized for
+     * the linked method — the supplier must propagate that as {@code Optional.empty()}, not
+     * {@code null}, so the advice can leave the assembler-provided self link untouched instead of
+     * overwriting it with a link built from a null-producing mapper.
+     */
+    public static void setSelfLinkSupplier(Supplier<Optional<Link>> selfLinkSupplier) {
+        setAttribute(SELF_LINK_SUPPLIER_ATTR, selfLinkSupplier);
+    }
+
+    @SuppressWarnings("unchecked")
+    static Supplier<Optional<Link>> takeSelfLinkSupplier() {
+        return (Supplier<Optional<Link>>) takeAttribute(SELF_LINK_SUPPLIER_ATTR);
+    }
+
+    static void clear() {
+        takeAttribute(SINGLE_DOMAIN_ATTR);
+        takeAttribute(DOMAIN_LIST_ATTR);
+        takeAttribute(SELF_LINK_SUPPLIER_ATTR);
+    }
+
+    private static void setAttribute(String name, Object value) {
+        ServletRequestAttributes attributes = currentAttributes();
+        if (attributes != null) {
+            attributes.setAttribute(name, value, ServletRequestAttributes.SCOPE_REQUEST);
+        }
+    }
+
+    private static Object takeAttribute(String name) {
+        ServletRequestAttributes attributes = currentAttributes();
+        if (attributes == null) {
+            return null;
+        }
+        Object value = attributes.getAttribute(name, ServletRequestAttributes.SCOPE_REQUEST);
+        attributes.removeAttribute(name, ServletRequestAttributes.SCOPE_REQUEST);
+        return value;
+    }
+
+    private static ServletRequestAttributes currentAttributes() {
+        return (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+    }
+}

--- a/backend/src/main/java/com/klabis/members/infrastructure/restapi/MemberController.java
+++ b/backend/src/main/java/com/klabis/members/infrastructure/restapi/MemberController.java
@@ -272,18 +272,7 @@ class MemberDetailsPostprocessor extends ModelWithDomainPostprocessor<MemberDeta
 
     @Override
     public void process(EntityModel<MemberDetailsResponse> dtoModel, Member member) {
-        UUID memberId = member.getId().uuid();
-
-        klabisLinkTo(methodOn(MemberController.class).getMember(memberId, null)).map(link -> {
-            var self = link.withSelfRel()
-                    .andAffordances(klabisAfford(methodOn(MemberController.class).updateMember(memberId, null, null)));
-            if (member.isActive()) {
-                self = self.andAffordances(klabisAfford(methodOn(MemberController.class).suspendMember(memberId, null, null)));
-            } else {
-                self = self.andAffordances(klabisAfford(methodOn(MemberController.class).resumeMember(memberId, null)));
-            }
-            return (Link) self;
-        }).ifPresent(dtoModel::add);
+        MemberSelfLinkSupport.addSelfLinkWithAffordances(dtoModel, member);
 
         klabisLinkTo(methodOn(MemberController.class).listMembers(Pageable.unpaged(), null, null, null))
                 .ifPresent(link -> dtoModel.add(link.withRel("collection")));
@@ -295,6 +284,21 @@ class MemberSummaryPostprocessor extends ModelWithDomainPostprocessor<MemberSumm
 
     @Override
     public void process(EntityModel<MemberSummaryResponse> dtoModel, Member member) {
+        MemberSelfLinkSupport.addSelfLinkWithAffordances(dtoModel, member);
+    }
+}
+
+/**
+ * Self link + status-dependent affordances (suspend/resume) are identical for the member detail
+ * and summary DTOs — the logic only touches {@code Member} and {@code RepresentationModel.add},
+ * neither of which depends on the DTO's generic type.
+ */
+final class MemberSelfLinkSupport {
+
+    private MemberSelfLinkSupport() {
+    }
+
+    static void addSelfLinkWithAffordances(RepresentationModel<?> dtoModel, Member member) {
         UUID memberId = member.getId().uuid();
 
         klabisLinkTo(methodOn(MemberController.class).getMember(memberId, null)).map(link -> {

--- a/backend/src/main/java/com/klabis/members/infrastructure/restapi/MemberController.java
+++ b/backend/src/main/java/com/klabis/members/infrastructure/restapi/MemberController.java
@@ -3,6 +3,7 @@ package com.klabis.members.infrastructure.restapi;
 import com.klabis.common.mvc.MvcComponent;
 import com.klabis.common.security.fieldsecurity.OwnerId;
 import com.klabis.common.security.fieldsecurity.OwnerVisible;
+import com.klabis.common.ui.HalResponseContext;
 import com.klabis.common.ui.ModelWithDomainPostprocessor;
 import com.klabis.common.ui.RootModel;
 import com.klabis.common.users.Authority;
@@ -28,7 +29,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.*;
 import org.springframework.hateoas.server.ExposesResourceFor;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
@@ -44,7 +44,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import static com.klabis.common.ui.HalFormsSupport.entityModelWithDomain;
 import static com.klabis.common.ui.HalFormsSupport.klabisAfford;
 import static com.klabis.common.ui.HalFormsSupport.klabisLinkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
@@ -60,17 +59,14 @@ public class MemberController {
 
     private final ManagementPort managementService;
     private final MemberRepository memberRepository;
-    private final PagedResourcesAssembler<Member> pagedResourcesAssembler;
     private final MemberMapper memberMapper;
 
     public MemberController(
             ManagementPort managementService,
             MemberRepository memberRepository,
-            PagedResourcesAssembler<Member> pagedResourcesAssembler,
             MemberMapper memberMapper) {
         this.managementService = managementService;
         this.memberRepository = memberRepository;
-        this.pagedResourcesAssembler = pagedResourcesAssembler;
         this.memberMapper = memberMapper;
     }
 
@@ -186,7 +182,7 @@ public class MemberController {
     @ApiResponse(responseCode = "200", description = "Paginated list of members retrieved successfully")
     @ApiResponse(responseCode = "400", description = "Invalid filter parameter value")
     @ApiResponse(responseCode = "403", description = "Forbidden - user is not an active member")
-    public ResponseEntity<PagedModel<EntityModel<MemberSummaryResponse>>> listMembers(
+    public ResponseEntity<Page<MemberSummaryResponse>> listMembers(
             @Parameter(description = "Pagination parameters: page, size, sort")
             @PageableDefault(size = 10, sort = {"lastName", "firstName"}, direction = Sort.Direction.ASC) @ParameterObject Pageable pageable,
             @Parameter(description = "Fulltext search over firstName, lastName, registrationNumber (min 2 chars)")
@@ -201,21 +197,17 @@ public class MemberController {
 
         Page<Member> memberPage = memberRepository.findAll(filter, pageable);
 
-        PagedModel<EntityModel<MemberSummaryResponse>> pagedModel = pagedResourcesAssembler.toModel(
-                memberPage,
-                member -> entityModelWithDomain(memberMapper.toSummaryResponse(member), member)
-        );
-
         String qForLink = (q == null) ? "" : q;
         String statusForLink = (status == null) ? "" : status;
-        klabisLinkTo(methodOn(MemberController.class).listMembers(pageable, qForLink, statusForLink, null)).ifPresent(selfLinkBuilder -> {
-            Link selfLink = selfLinkBuilder.withSelfRel()
-                    .andAffordances(klabisAfford(methodOn(MemberController.class).updateMember(null, null, null)))
-                    .andAffordances(klabisAfford(methodOn(RegistrationController.class).registerMember(null, null)));
-            pagedModel.mapLink(IanaLinkRelations.SELF, oldLink -> selfLink);
-        });
 
-        return ResponseEntity.ok(pagedModel);
+        HalResponseContext.setDomainList(memberPage.getContent());
+        HalResponseContext.setSelfLinkSupplier(() ->
+                klabisLinkTo(methodOn(MemberController.class).listMembers(pageable, qForLink, statusForLink, null))
+                        .map(selfLinkBuilder -> (Link) selfLinkBuilder.withSelfRel()
+                                .andAffordances(klabisAfford(methodOn(MemberController.class).updateMember(null, null, null)))
+                                .andAffordances(klabisAfford(methodOn(RegistrationController.class).registerMember(null, null)))));
+
+        return ResponseEntity.ok(memberPage.map(memberMapper::toSummaryResponse));
     }
 
     private MemberFilter buildFilter(String q, String status, CurrentUserData currentUser) {
@@ -269,7 +261,7 @@ public class MemberController {
                           "contact details, and guardian information if applicable. Returns HATEOAS links for navigation."
     )
     @ApiResponse(responseCode = "200", description = "Member found")
-    public ResponseEntity<EntityModel<MemberDetailsResponse>> getMember(
+    public ResponseEntity<MemberDetailsResponse> getMember(
             @Parameter(description = "Member UUID") @PathVariable UUID id,
             @ActingUser CurrentUserData currentUser) {
 
@@ -277,7 +269,8 @@ public class MemberController {
         Member member = managementService.getMemberAndRecordView(memberId, currentUser.userId(),
                 currentUser.hasAuthority(Authority.MEMBERS_MANAGE));
 
-        return ResponseEntity.ok(entityModelWithDomain(memberMapper.toDetailsResponse(member), member));
+        HalResponseContext.setDomain(member);
+        return ResponseEntity.ok(memberMapper.toDetailsResponse(member));
     }
 
 }

--- a/backend/src/main/java/com/klabis/members/infrastructure/restapi/MemberController.java
+++ b/backend/src/main/java/com/klabis/members/infrastructure/restapi/MemberController.java
@@ -197,15 +197,7 @@ public class MemberController {
 
         Page<Member> memberPage = memberRepository.findAll(filter, pageable);
 
-        String qForLink = (q == null) ? "" : q;
-        String statusForLink = (status == null) ? "" : status;
-
         HalResponseContext.setDomainList(memberPage.getContent());
-        HalResponseContext.setSelfLinkSupplier(() ->
-                klabisLinkTo(methodOn(MemberController.class).listMembers(pageable, qForLink, statusForLink, null))
-                        .map(selfLinkBuilder -> (Link) selfLinkBuilder.withSelfRel()
-                                .andAffordances(klabisAfford(methodOn(MemberController.class).updateMember(null, null, null)))
-                                .andAffordances(klabisAfford(methodOn(RegistrationController.class).registerMember(null, null)))));
 
         return ResponseEntity.ok(memberPage.map(memberMapper::toSummaryResponse));
     }
@@ -315,6 +307,18 @@ class MemberSummaryPostprocessor extends ModelWithDomainPostprocessor<MemberSumm
             }
             return (Link) self;
         }).ifPresent(dtoModel::add);
+    }
+}
+
+@MvcComponent
+class MemberListPostprocessor implements RepresentationModelProcessor<PagedModel<EntityModel<MemberSummaryResponse>>> {
+
+    @Override
+    public PagedModel<EntityModel<MemberSummaryResponse>> process(PagedModel<EntityModel<MemberSummaryResponse>> pagedModel) {
+        pagedModel.mapLink(IanaLinkRelations.SELF, selfLink -> (Link) selfLink
+                .andAffordances(klabisAfford(methodOn(MemberController.class).updateMember(null, null, null)))
+                .andAffordances(klabisAfford(methodOn(RegistrationController.class).registerMember(null, null))));
+        return pagedModel;
     }
 }
 

--- a/backend/src/test/java/com/klabis/common/ui/HalResponseBodyAdviceTest.java
+++ b/backend/src/test/java/com/klabis/common/ui/HalResponseBodyAdviceTest.java
@@ -3,10 +3,7 @@ package com.klabis.common.ui;
 import com.klabis.common.WithKlabisMockUser;
 import com.klabis.common.WithPostprocessors;
 import com.klabis.common.mvc.MvcComponent;
-import com.klabis.common.users.Authority;
-import com.klabis.common.users.HasAuthority;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -23,27 +20,23 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.Optional;
 
-import static com.klabis.common.ui.HalFormsSupport.klabisLinkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * Regression test for {@link HalResponseBodyAdvice#wrapPage}: when a controller's self-link
- * supplier resolves to {@link Optional#empty()} (target method not authorized for the current
- * user), the assembler-provided self link must be left untouched — not overwritten with {@code null}.
- * <p>
- * {@code klabisLinkTo} returns {@code Optional.empty()} when the caller lacks authority for the
- * linked method. Before the fix, the supplier collapsed that to a bare {@code null} via
- * {@code orElse(null)}, and {@code PagedModel.mapLink} has no null check — it unconditionally
- * removes the old link and adds whatever the mapping function returns, corrupting {@code _links.self}.
+ * Regression test for {@link HalResponseBodyAdvice#wrapPage}: the collection-level self link is
+ * derived directly from the current request's URI and query string via {@code ServerHttpRequest},
+ * not re-built via {@code klabisLinkTo(methodOn(...))}. The controller method already ran (and
+ * passed authorization) for exactly that URI, so no separate authorization check applies to the
+ * self link itself — only affordances to *other* endpoints (added by a postprocessor, see
+ * {@code MemberListPostprocessor}) still go through {@code klabisAfford} and stay
+ * authorization-sensitive.
  */
 @WebMvcTest(controllers = HalResponseBodyAdviceTest.SelfLinkTestController.class)
 @Import(HalFormsSupport.class)
-@DisplayName("HalResponseBodyAdvice self-link supplier handling")
+@DisplayName("HalResponseBodyAdvice self link handling for paged responses")
 @WithPostprocessors
 class HalResponseBodyAdviceTest {
 
@@ -64,49 +57,22 @@ class HalResponseBodyAdviceTest {
                     PageRequest.of(0, 10), domain.size());
 
             HalResponseContext.setDomainList(domain);
-            HalResponseContext.setSelfLinkSupplier(() ->
-                    klabisLinkTo(methodOn(SelfLinkTestController.class).securedTarget())
-                            .map(builder -> builder.withSelfRel()));
 
             return ResponseEntity.ok(page);
         }
-
-        @GetMapping(value = "/api/self-link-test/secured", produces = MediaTypes.HAL_FORMS_JSON_VALUE)
-        @HasAuthority(Authority.MEMBERS_MANAGE)
-        ResponseEntity<Void> securedTarget() {
-            return ResponseEntity.noContent().build();
-        }
     }
 
-    @Nested
-    @DisplayName("self-link supplier target requires an authority the caller lacks")
-    class SupplierResolvesToEmpty {
-
-        @Test
-        @WithKlabisMockUser(username = "noAuthUser")
-        @DisplayName("assembler-provided self link is kept, not overwritten with null")
-        void keepsAssemblerSelfLinkWhenSupplierIsEmpty() throws Exception {
-            mockMvc.perform(get("/api/self-link-test/items").accept(MediaTypes.HAL_FORMS_JSON_VALUE))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$._links.self.href").exists())
-                    .andExpect(jsonPath("$._links.self.href").value(
-                            org.hamcrest.Matchers.containsString("/api/self-link-test/items")));
-        }
-    }
-
-    @Nested
-    @DisplayName("self-link supplier target is authorized")
-    class SupplierResolvesToPresent {
-
-        @Test
-        @WithKlabisMockUser(authorities = {Authority.MEMBERS_MANAGE})
-        @DisplayName("self link is overwritten with the supplier's link")
-        void overwritesSelfLinkWhenSupplierIsPresent() throws Exception {
-            mockMvc.perform(get("/api/self-link-test/items").accept(MediaTypes.HAL_FORMS_JSON_VALUE))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$._links.self.href").exists())
-                    .andExpect(jsonPath("$._links.self.href").value(
-                            org.hamcrest.Matchers.containsString("/api/self-link-test/secured")));
-        }
+    @Test
+    @WithKlabisMockUser
+    @DisplayName("self link reflects the actual request URI, including query parameters not known to PagedResourcesAssembler")
+    void selfLinkReflectsActualRequestUri() throws Exception {
+        mockMvc.perform(get("/api/self-link-test/items").param("size", "10").param("extra", "keep-me")
+                        .accept(MediaTypes.HAL_FORMS_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._links.self.href").exists())
+                .andExpect(jsonPath("$._links.self.href").value(
+                        org.hamcrest.Matchers.allOf(
+                                org.hamcrest.Matchers.containsString("/api/self-link-test/items"),
+                                org.hamcrest.Matchers.containsString("extra=keep-me"))));
     }
 }

--- a/backend/src/test/java/com/klabis/common/ui/HalResponseBodyAdviceTest.java
+++ b/backend/src/test/java/com/klabis/common/ui/HalResponseBodyAdviceTest.java
@@ -1,0 +1,112 @@
+package com.klabis.common.ui;
+
+import com.klabis.common.WithKlabisMockUser;
+import com.klabis.common.WithPostprocessors;
+import com.klabis.common.mvc.MvcComponent;
+import com.klabis.common.users.Authority;
+import com.klabis.common.users.HasAuthority;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.klabis.common.ui.HalFormsSupport.klabisLinkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Regression test for {@link HalResponseBodyAdvice#wrapPage}: when a controller's self-link
+ * supplier resolves to {@link Optional#empty()} (target method not authorized for the current
+ * user), the assembler-provided self link must be left untouched — not overwritten with {@code null}.
+ * <p>
+ * {@code klabisLinkTo} returns {@code Optional.empty()} when the caller lacks authority for the
+ * linked method. Before the fix, the supplier collapsed that to a bare {@code null} via
+ * {@code orElse(null)}, and {@code PagedModel.mapLink} has no null check — it unconditionally
+ * removes the old link and adds whatever the mapping function returns, corrupting {@code _links.self}.
+ */
+@WebMvcTest(controllers = HalResponseBodyAdviceTest.SelfLinkTestController.class)
+@Import(HalFormsSupport.class)
+@DisplayName("HalResponseBodyAdvice self-link supplier handling")
+@WithPostprocessors
+class HalResponseBodyAdviceTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    record TestItemResponse(String value) {}
+
+    @MvcComponent
+    @RestController
+    static class SelfLinkTestController {
+
+        @GetMapping(value = "/api/self-link-test/items", produces = MediaTypes.HAL_FORMS_JSON_VALUE)
+        ResponseEntity<Page<TestItemResponse>> listItems(@PageableDefault Pageable pageable) {
+            List<String> domain = List.of("a", "b");
+            Page<TestItemResponse> page = new PageImpl<>(
+                    domain.stream().map(TestItemResponse::new).toList(),
+                    PageRequest.of(0, 10), domain.size());
+
+            HalResponseContext.setDomainList(domain);
+            HalResponseContext.setSelfLinkSupplier(() ->
+                    klabisLinkTo(methodOn(SelfLinkTestController.class).securedTarget())
+                            .map(builder -> builder.withSelfRel()));
+
+            return ResponseEntity.ok(page);
+        }
+
+        @GetMapping(value = "/api/self-link-test/secured", produces = MediaTypes.HAL_FORMS_JSON_VALUE)
+        @HasAuthority(Authority.MEMBERS_MANAGE)
+        ResponseEntity<Void> securedTarget() {
+            return ResponseEntity.noContent().build();
+        }
+    }
+
+    @Nested
+    @DisplayName("self-link supplier target requires an authority the caller lacks")
+    class SupplierResolvesToEmpty {
+
+        @Test
+        @WithKlabisMockUser(username = "noAuthUser")
+        @DisplayName("assembler-provided self link is kept, not overwritten with null")
+        void keepsAssemblerSelfLinkWhenSupplierIsEmpty() throws Exception {
+            mockMvc.perform(get("/api/self-link-test/items").accept(MediaTypes.HAL_FORMS_JSON_VALUE))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$._links.self.href").exists())
+                    .andExpect(jsonPath("$._links.self.href").value(
+                            org.hamcrest.Matchers.containsString("/api/self-link-test/items")));
+        }
+    }
+
+    @Nested
+    @DisplayName("self-link supplier target is authorized")
+    class SupplierResolvesToPresent {
+
+        @Test
+        @WithKlabisMockUser(authorities = {Authority.MEMBERS_MANAGE})
+        @DisplayName("self link is overwritten with the supplier's link")
+        void overwritesSelfLinkWhenSupplierIsPresent() throws Exception {
+            mockMvc.perform(get("/api/self-link-test/items").accept(MediaTypes.HAL_FORMS_JSON_VALUE))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$._links.self.href").exists())
+                    .andExpect(jsonPath("$._links.self.href").value(
+                            org.hamcrest.Matchers.containsString("/api/self-link-test/secured")));
+        }
+    }
+}

--- a/backend/src/test/java/com/klabis/common/ui/HalResponseContextLeakTest.java
+++ b/backend/src/test/java/com/klabis/common/ui/HalResponseContextLeakTest.java
@@ -1,0 +1,62 @@
+package com.klabis.common.ui;
+
+import com.klabis.common.WithKlabisMockUser;
+import com.klabis.common.WithPostprocessors;
+import com.klabis.common.mvc.MvcComponent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.ErrorResponseException;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Regression test for {@link HalResponseBodyAdvice}: a controller that stores a domain object in
+ * {@link HalResponseContext} and then fails must not have its error body wrapped into an
+ * {@code EntityModel} carrying that now-stale domain object.
+ */
+@WebMvcTest(controllers = HalResponseContextLeakTest.LeakTestController.class)
+@Import(HalFormsSupport.class)
+@DisplayName("HalResponseContext leaking into an error response")
+@WithPostprocessors
+class HalResponseContextLeakTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    record LeakTestResponse(String value) {}
+
+    @MvcComponent
+    @RestController
+    static class LeakTestController {
+
+        @GetMapping(value = "/api/leak-test/fails-after-context-set", produces = MediaTypes.HAL_FORMS_JSON_VALUE)
+        ResponseEntity<LeakTestResponse> failsAfterContextSet() {
+            HalResponseContext.setDomain("leaked-domain-object");
+            throw new ErrorResponseException(HttpStatus.NOT_FOUND,
+                    ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, "nothing here"), null);
+        }
+    }
+
+    @Test
+    @WithKlabisMockUser
+    @DisplayName("error body stays a plain ProblemDetail, not an EntityModel")
+    void errorResponseIsNotWrappedWithStaleDomain() throws Exception {
+        mockMvc.perform(get("/api/leak-test/fails-after-context-set").accept(MediaTypes.HAL_FORMS_JSON_VALUE))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.detail").value("nothing here"))
+                .andExpect(jsonPath("$._links").doesNotExist());
+    }
+}

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -34,3 +34,48 @@ This inconsistency made dependency rules unpredictable, let new modules couple t
 - Slightly more indirection: a module that only needs read data must still expose (or reuse) a primary port rather than letting consumers reach into its repository.
 
 **References:** OpenSpec change `unify-cross-module-ports`.
+
+## ADR-002: Controllers return plain DTOs; `HalResponseBodyAdvice` wraps them into HAL models
+
+**Status:** Accepted
+
+**Context:**
+
+The backend is migrating from code-first (springdoc) to spec-first OpenAPI generation: `docs/openapi/spec/` becomes the source of truth, and both Java DTOs and frontend types are generated from it. The `openapi-generator` `spring` generator produces Java **interfaces** for controllers to implement, with return types derived strictly from the OpenAPI response schemas — plain payload DTOs (records), never `EntityModel<T>`/`PagedModel<EntityModel<T>>`.
+
+This conflicted with the project's existing HATEOAS convention (see the `backend-patterns` skill before this change): controllers built `EntityModel`/`PagedModel` directly — via `entityModelWithDomain(dto, domain)` for single items, or `PagedResourcesAssembler` plus an inline `klabisLinkTo(...).withSelfRel().andAffordances(...)` call for collections — and returned that wrapped type from the method signature.
+
+Three ways to reconcile this with the generator were evaluated and rejected:
+
+1. **`hateoas=true` generator option.** Decompiling `openapi-generator` showed this makes generated model classes `extend RepresentationModel<T>` — a single line in `pojo.mustache`. Records cannot extend a class, so this is incompatible with the project's record-based DTOs, and would additionally break `FieldSecurityBeanSerializerModifier` (reads annotations off record accessors only), `@RecordBuilder`, and MapStruct mapping.
+2. **`schemaMappings` to a custom HAL wrapper type.** No generic parameter support in the generator's schema-mapping mechanism — cannot express `EntityModel<GeneratedDto>` this way without hand-writing every wrapper permutation.
+3. **`responseWrapper` config option.** Verified experimentally: `responseType.mustache` places the configured wrapper **outside** `ResponseEntity`, not inside — it is designed for `CompletableFuture<ResponseEntity<T>>`, not `ResponseEntity<Wrapper<T>>`. Produces the wrong nesting (`EntityModel<ResponseEntity<T>>`) and cannot be corrected via configuration.
+
+A fourth option — permanently forking the schema to carry both a plain DTO and a HAL envelope, verified only at the boundary — was rejected earlier in the same investigation as adding a permanent dual-mode maintenance burden for no runtime benefit.
+
+**Decision:**
+
+Controllers return the plain DTO type the generated API interface requires (`ResponseEntity<SomeResponse>` / `ResponseEntity<Page<SomeResponse>>`). Before returning, a controller stashes the domain object(s) backing the DTO in a request-scoped `HalResponseContext` (`com.klabis.common.ui`):
+
+```java
+HalResponseContext.setDomain(member);                    // single item
+HalResponseContext.setDomainList(memberPage.getContent()); // Page content, same order
+```
+
+`HalResponseBodyAdvice`, a `ResponseBodyAdvice<Object>` registered as `@MvcComponent @ControllerAdvice`, runs in `beforeBodyWrite` and:
+
+- Passes through unchanged anything that is not a HAL/HAL-FORMS media type (checked via `MediaTypes.HAL_JSON`/`HAL_FORMS_JSON` against `selectedContentType`), or any `ProblemDetail` error body — clearing the context in both cases so nothing leaks into a later request on the same thread.
+- For a single DTO with a stashed domain object: wraps it in `EntityModelWithDomain<T, D>` (the same class the pre-existing postprocessor pattern already used) and runs it through every `RepresentationModelProcessor` bean via `RepresentationModelProcessorInvoker` — so existing `ModelWithDomainPostprocessor<Dto, Aggregate>` postprocessors require no changes.
+- For a `Page<Dto>` with a stashed domain list: runs it through `PagedResourcesAssembler`, pairing each DTO with its domain object by index, then derives the **collection self link directly from the current request's path and parameters** (`HttpServletRequest.getRequestURI()` + a sorted `getParameterMap()`, decoded and re-encoded together to avoid double-encoding) — no `klabisLinkTo` authorization re-check is needed for the self link itself, since the controller method already ran and passed authorization for exactly this request. Collection-level affordances to *other* endpoints (which remain authorization-sensitive) are added separately by a plain `RepresentationModelProcessor<PagedModel<EntityModel<Dto>>>` (e.g. `MemberListPostprocessor`), not by the advice.
+
+Why this works without an ordering conflict: Spring HATEOAS's own postprocessing (`RepresentationModelProcessorHandlerMethodReturnValueHandler`) only recognizes return values that are already a `RepresentationModel`. A plain DTO never satisfies that check, so HATEOAS skips postprocessing entirely for these endpoints — `HalResponseBodyAdvice` is the only thing invoking postprocessors for them, not something racing or double-running against the framework's own mechanism.
+
+**Consequences:**
+
+- A module can adopt spec-first OpenAPI generation for its controllers without abandoning the existing HATEOAS postprocessor pattern — `ModelWithDomainPostprocessor` subclasses are reused unchanged.
+- Two request-scoped context slots (`setDomain`/`setDomainList`) are a new implicit contract: a controller **must** call them after all code that can throw, or a subsequent exception leaves stale context data that the `ProblemDetail` guard must clear defensively rather than the controller guaranteeing correctness by construction.
+- Collection self-link construction moved out of controllers entirely and became generic (path + parameters from the request), removing a `klabisLinkTo(methodOn(...).listMembers(pageable, q, status, null))` call that had to be kept in sync with the method's own parameter list by hand.
+- Not yet a project-wide requirement: as of this ADR, only two `MemberController` endpoints (`getMember`, `listMembers`) use this pattern; the rest of the codebase still returns `EntityModel`/`PagedModel` directly. Migrating the remaining modules to spec-first generation (and this pattern) is a separate, module-by-module decision.
+- No dedicated abstraction yet exists for the collection-level `RepresentationModelProcessor<PagedModel<EntityModel<Dto>>>` postprocessor (unlike `ModelWithDomainPostprocessor` for single items) — `MemberListPostprocessor` is a one-off; a shared base class is worth introducing once a second module needs the same shape.
+
+**References:** PR #299 (`worktree-hal-response-advice`), `backend-patterns` skill.


### PR DESCRIPTION
Draft (proof of concept) pro migraci na API-spec-first vývoj.

## Proč

Generování API interfaces z OpenAPI specu (fáze 4) narazilo na to, že controllery vrací `ResponseEntity<EntityModel<MemberDetailsResponse>>`, zatímco generátor umí jen `ResponseEntity<MemberDetailsResponse>`. Experimentálně ověřeno, že to nejde obejít:

| mechanismus | proč ne |
|---|---|
| `hateoas=true` | `extends RepresentationModel` — nekompatibilní s recordy |
| `schemaMappings` | mapuje jen prostá jména tříd, ne generika |
| `responseWrapper` | obaluje naruby — `EntityModel<ResponseEntity<T>>` |

## Jak

Controller vrátí čistý payload a uloží doménový objekt do `HalResponseContext`. `HalResponseBodyAdvice` ho vyzvedne, obalí do `EntityModelWithDomain` a spustí stávající postprocessory.

Spring HATEOAS aplikuje své postprocessory jen na návratové hodnoty, které **už jsou** `RepresentationModel` — plain DTO tu podmínku nesplní, takže se jeho pipeline přeskočí. Tato advice je to, co postprocessory v takovém případě spustí.

## Rozsah

Pouze `MemberController.getMember` a `listMembers`. Ostatní controllery staví modely dál po starém a jsou nedotčené — koexistence obou mechanismů je záměr, aby migrace mohla být postupná.

## Ověření

- **3186 testů, 0 selhání, 0 chyb**, 15 přeskočených (parsováno z 828 XML souborů)
- `docs/openapi/klabis-full.json` bit-identický (md5 `ca397906af263418c8f15db8859bd6de`)
- field-security anotace beze změny: 31 (1 `@OwnerId`, 13 `@OwnerVisible`, 17 `@HasAuthority`)
- HAL výstup identický — stejné `_links`, stejné `_templates`

## Dvě chyby nalezené při code review

**`mapLink` s `orElse(null)`** — `klabisLinkTo` vrací `Optional.empty()` pro neautorizovaného volajícího; `RepresentationModel.mapLinkIf` dělá `links.remove(old); links.add(fn.apply(old))` bez null-checku, takže by se do `_links` vložil `null`. Opraveno na `Supplier<Optional<Link>>` + `ifPresent`.

**Únik kontextu do chybové odpovědi** — když controller uložil doménový objekt a pak selhal, advice obalila `ProblemDetail` do `EntityModel` s cizí doménou a chybové tělo se ztratilo. Opraveno guardem + `HalResponseContext.clear()`.

Obě chyby pokryty regresními testy; u obou ověřeno, že test na vadném kódu selže.

## Otevřené otázky pro širší rollout

- **Self-link supplier** je druhý typ kontextu vedle doménového objektu; potřebuje ho každá kolekce se self odkazem závislým na query parametrech. Před rolloutem by to chtělo formalizovat.
- **Kolekční postprocessory** jako koncept v kódu neexistovaly — mutace self odkazu je teď přímo v advice. Reálná migrace by chtěla abstrakci obdobnou `ModelWithDomainPostprocessor`.
- Zbývá 14 postprocessorů; z analýzy 11 ze 16 potřebuje jen ID nebo stav dostupný v payloadu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)