### PR TITLE
feat(openapi): migrate finance and calendar modules to spec-first

### DIFF
--- a/.claude/skills/klabis-api-spec/SKILL.md
+++ b/.claude/skills/klabis-api-spec/SKILL.md
@@ -285,6 +285,24 @@ MemberDetailsResponse:                 # payload; this is what becomes a record
 Same rule for `_embedded` and `page` on collections — they belong to `PagedModel*` /
 `CollectionModel*`, not to the item.
 
+### Bodyless success responses still need an empty HAL content block
+
+A `201` or `204` with no `content:` at all generates a method whose `produces` lists only
+`application/problem+json` (inherited from the error responses). A client that sends
+`Accept: application/prs.hal-forms+json` — as the frontend does on every request — then gets **406
+Not Acceptable** instead of the success status. Declare the media type with an empty schema:
+
+```yaml
+        '204':
+          description: Calendar item successfully updated
+          content:
+            application/prs.hal-forms+json: {}
+```
+
+No body is produced; this only pins the negotiated media type. Easy to miss because MockMvc tests
+that omit `.accept(...)` pass either way — the gap surfaces only against a real client, or a test that
+sets the header.
+
 ### The response must reference the envelope — always
 
 A response references the `EntityModel*` / `PagedModel*` / `CollectionModel*` schema, never the bare
@@ -429,7 +447,18 @@ Consequences:
   `description` and in the OpenSpec design.md prose.
 - Never write a spec implying a link is always present.
 
-## Workflow for an API change
+### Linking to an operation in a module that is not migrated yet
+
+`operation:` is validated against the bundled `operationId`s, so a link pointing into a module that
+is still code-first fails the bundle:
+
+```
+/paths/.../x-hal-links/event: operation "getEvent" does not match any operationId
+```
+
+`operation` is optional — a descriptor carrying only `description` validates. Document the link now,
+leave a note, and attach `operation:` when the target module lands. Do not delete the rel (the link
+exists at runtime and the frontend types should know about it), and do not relax the validator.
 
 The spec moves first.
 
@@ -478,6 +507,14 @@ tag when given an empty string, which would emit every other module's `*Api.java
 package. Forgetting a tag is safe by comparison: the interface is simply not generated and
 `implements XApi` fails to compile.
 
+**Tags must be single words.** A tag containing a space (`Calendar Feed Token`, `Event
+Registrations`, `My Profile`) is silently dropped: the build succeeds, no warning is printed, and the
+interface simply never appears. Watch for a trailing space too — `"Members "` is not `"Members"`.
+Existing controllers carry several multi-word `@Tag` names, so when migrating one, give the spec a
+single-word tag (`IcalToken`, not `Calendar Feed Token`) and use that same string in `apis`. The tag
+is spec-side only, so renaming it changes neither the wire nor `klabis-full.json`, which takes its
+tags from `@Tag` on the controller.
+
 **The generator never deletes.** It only writes, so a schema you rename or drop leaves its old record
 behind in `build/generated/openapi/<module>/`— and since that directory is on `sourceSets.main`, the
 ghost keeps compiling. Local builds stay green while a clean CI build fails. `openApiModule` handles
@@ -504,7 +541,12 @@ this with `doFirst { delete(outputDir) }`; keep it when touching that function.
    because an imperative check is invisible both to reflection and to the drift check.
 6. Register the module with `openApiModule(...)` (above), then `./gradlew compileJava`
 7. Rework the controller: implement the generated `*Api`, return plain payloads, and register the
-   domain objects with `HalResponseContext` (below)
+   domain objects with `HalResponseContext` (below).
+   **Strip the path from the class-level `@RequestMapping`.** Generated interface methods carry the
+   full absolute path, so a controller that still declares `@RequestMapping(value = "/api/foo")`
+   makes Spring concatenate the two into `/api/foo/api/foo` and every endpoint 404s. Keep the
+   annotation for `produces` only: `@RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)`,
+   as `MemberAccountController` and `EventTypeController` do.
 8. Re-run the drift check until the module reports `mismatched: 0`
 9. `cd frontend && npm run openapi`, then `npx tsc --noEmit -p tsconfig.app.json`
 
@@ -584,6 +626,12 @@ returns `true` unconditionally makes the test assert nothing.
   `@Relation(collectionRelation = ...)`, which overrides it
 - Reusing a generic component name (`MemberIdParam`) across module files — component names are one
   global namespace after bundling; prefix them per module
+- Leaving the path on a class-level `@RequestMapping` after the controller starts implementing a
+  generated `*Api` — the path doubles and every endpoint 404s
+- Writing a `201`/`204` with no `content:` block — the endpoint then answers 406 to any client that
+  sends `Accept: application/prs.hal-forms+json`
+- Giving an operation a multi-word `tags:` value — the generator drops it silently and the `*Api`
+  interface never appears
 - Mapping an envelope schema onto `java.util.List<...>`; the generator drops it silently
 - Concluding an endpoint needs no authority because the controller has no annotation — check the
   method body for an imperative `checkXxxAccess()` first

--- a/.claude/skills/klabis-api-spec/SKILL.md
+++ b/.claude/skills/klabis-api-spec/SKILL.md
@@ -103,6 +103,28 @@ serves it, not by the URL prefix.
 Reusable parameters and error responses go in the module's own `components`; only genuinely
 cross-module building blocks belong in `_shared/`.
 
+**Component names are global once bundled, even though they are defined per module.** Files are
+namespaced; `components.parameters` / `components.responses` / `components.schemas` entries are not —
+bundling flattens them all into one namespace. Two modules defining the same name with different
+content is a hard bundle failure (the message names the same file twice, which reads as nonsense
+until you know it is a cross-file collision):
+
+```yaml
+# members.yaml            # finance.yaml
+MemberIdParam:            MemberIdParam:
+  name: id                  name: memberId      # same name, different shape -> bundle fails
+```
+
+Prefix module-owned components rather than reaching for the generic name: `AccountMemberIdParam`,
+not `MemberIdParam`. This applies to `responses` too — a shared error response whose `description`
+wording differs from another module's copy of the same name collides the same way, so match the
+existing wording exactly or pick a distinct name.
+
+A name collision can also surface far from its cause: if a colliding parameter component resolves to
+the *other* module's definition, `x-klabis-owner-visible: <name>` then fails with "not declared on
+that operation" even though the operation's own file looks correct. Check for a duplicate component
+name before believing the error at face value.
+
 ## Validation lives in the spec too
 
 Bean-validation constraints are generated from standard OpenAPI keywords, so they belong in the spec
@@ -315,6 +337,25 @@ CollectionModelEntityModelEventTypeDto:
             $ref: '#/components/schemas/EntityModelEventTypeDto'
 ```
 
+**`@Relation` overrides that default.** The class-name rule above only holds when the payload class
+carries no `@Relation`. When it does, the annotation wins and the spec must spell the annotation's
+value:
+
+```java
+@Relation(collectionRelation = "transactions", itemRelation = "transaction")
+public record TransactionResource(...) { }
+```
+```yaml
+_embedded:
+  type: object
+  properties:
+    transactions:              # from @Relation, NOT "transactionResourceList"
+```
+
+So before writing an envelope, grep the payload class for `@Relation` rather than deriving the key
+from its name. Applying the default to a class that overrides it produces a key no response ever
+contains, and — per the second guard below — nothing reports it.
+
 Two guards, both worth knowing because each fails at a different moment:
 
 - **`halTypes.ts` indexes into `klabisApi.d.ts`** by schema name
@@ -456,6 +497,11 @@ this with `doFirst { delete(outputDir) }`; keep it when touching that function.
    operation, then delete it from the controller. Compare the generated `*Api` interface against the
    controller as it was — an authority that silently changes or disappears here is not something the
    tests will necessarily catch
+   Authorization is not always an annotation. A controller may enforce it **imperatively** — a
+   private `checkXxxAccess()` throwing `AccessDeniedException`, typically "owner OR MANAGE
+   authority". That is the `x-klabis-authority` + `x-klabis-owner-visible` pair; move it into the
+   spec and delete the helper. Read each method body before concluding an endpoint is unprotected,
+   because an imperative check is invisible both to reflection and to the drift check.
 6. Register the module with `openApiModule(...)` (above), then `./gradlew compileJava`
 7. Rework the controller: implement the generated `*Api`, return plain payloads, and register the
    domain objects with `HalResponseContext` (below)
@@ -498,6 +544,32 @@ Expect the springdoc output to be wrong in places (it does not know about `@Json
 `PatchField` deserializer). Where it disagrees with the actual wire format, the spec follows the
 **wire**, and the discrepancy is documented in the spec rather than mirrored.
 
+### A newly annotated method can fail a link/affordance unit test
+
+Moving authorization into the spec makes it **discoverable by reflection** for the first time. That
+can break a passing unit test without any behaviour changing, and the failure looks alarming — a HAL
+link silently disappears.
+
+The cause is in `HalFormsSupport`: every `klabisLinkTo` / `klabisAfford*` guard reads
+`INSTANCE != null && !INSTANCE.isMethodAuthorized(...)`. `INSTANCE` is a static set by
+`@PostConstruct`, so in a plain unit test with no Spring context it is null and **authorization is
+skipped entirely**. Such a test passes without ever exercising the check. Once the target method
+carries `@HasAuthority` / `@OwnerVisible`, a leftover `INSTANCE` from another test class's context in
+the same fork activates the real check — and `isMethodAuthorized` returns `false` unless an
+`OwnershipResolver` is actually available, since the ownership branch falls through to `return false`
+when `ownershipResolverProvider.getIfAvailable()` is null.
+
+Symptom: the test passes standalone and fails when run after any `@SpringBootTest` in the same fork.
+
+Fix the test, not the assertion — and verify the production behaviour separately (the module's
+MockMvc controller test with `@WithKlabisMockUser` is the real evidence, since it exercises genuine
+authentication). Either wire a real `OwnershipResolver` into a `HalFormsSupport` and set `INSTANCE`
+for the test's duration (`AccountRootLinkProcessorTest` and `AccountMemberDetailLinkProcessorTest`
+do this, and must restore the previous value afterwards or they leak the same problem onward), or use
+the `@WebMvcTest` + `@Import(HalFormsSupport.class)` + `@WithKlabisMockUser` slice that
+`AffordanceAuthorizationTest` uses. Give the resolver the real UUID-comparison semantics; one that
+returns `true` unconditionally makes the test assert nothing.
+
 ## Anti-patterns
 
 - Editing generated output: `build/generated/**`, `docs/openapi/klabis-full.json`,
@@ -508,7 +580,16 @@ Expect the springdoc output to be wrong in places (it does not know about `@Json
 - Pointing a response at a bare `type: array` or the raw payload instead of the `EntityModel*` /
   `PagedModel*` / `CollectionModel*` envelope, to get a nicer Java signature
 - Renaming a payload schema for tidiness — it renames the `_embedded` key on the wire
+- Deriving the `_embedded` key from the class name without checking the payload class for
+  `@Relation(collectionRelation = ...)`, which overrides it
+- Reusing a generic component name (`MemberIdParam`) across module files — component names are one
+  global namespace after bundling; prefix them per module
 - Mapping an envelope schema onto `java.util.List<...>`; the generator drops it silently
+- Concluding an endpoint needs no authority because the controller has no annotation — check the
+  method body for an imperative `checkXxxAccess()` first
+- Relaxing an assertion in a link/affordance unit test that started failing after authorization moved
+  into the spec — the test was passing only because `HalFormsSupport.INSTANCE` was null; wire it a
+  real `OwnershipResolver` instead
 - Writing `@HasAuthority` on a controller method — the authority belongs in `x-klabis-authority`,
   stated once
 - Stripping `@Operation` / `@ApiResponse` / `@Parameter` off a controller because "the spec already

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -442,3 +442,25 @@ openApiModule(
         "CollectionModelEntityModelEventTypeDto" to "java.util.Collection"
     )
 )
+
+openApiModule(
+    module = "finance",
+    pkg = "com.klabis.finance.infrastructure.restapi",
+    apis = listOf("Finance"),
+    // MemberAccountResource/TransactionResource are hand-written (mapper logic onto Money/Transaction
+    // domain types) and stay that way — only the request DTOs are generated fresh.
+    models = listOf(
+        "DepositRequest",
+        "ChargeRequest",
+        "ReverseRequest"
+    ),
+    mappings = mapOf(
+        "EntityModelMemberAccountResource" to "com.klabis.finance.infrastructure.restapi.MemberAccountResource",
+        "EntityModelTransactionResource" to "com.klabis.finance.infrastructure.restapi.TransactionResource",
+        "PagedModelEntityModelTransactionResource" to "org.springframework.data.domain.Page<com.klabis.finance.infrastructure.restapi.TransactionResource>"
+    ),
+    // The generic Page<T> mapping above carries type arguments that the import must not repeat.
+    extraImportMappings = mapOf(
+        "PagedModelEntityModelTransactionResource" to "org.springframework.data.domain.Page"
+    )
+)

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -464,3 +464,26 @@ openApiModule(
         "PagedModelEntityModelTransactionResource" to "org.springframework.data.domain.Page"
     )
 )
+openApiModule(
+    module = "calendar",
+    pkg = "com.klabis.calendar.infrastructure.restapi",
+    // "Calendar Feed" is deliberately absent: /ical/my-schedule.ics returns a raw RFC 5545 string
+    // rather than a DTO, sits outside /api/, and authenticates via a ?token= query parameter. An
+    // interface for it would generate nothing worth implementing against, so IcalFeedController
+    // stays hand-written. The spec still describes the endpoint.
+    apis = listOf("Calendar", "IcalToken"),
+    // CalendarItemDto and IcalTokenResponse are hand-written; only the request DTOs are generated.
+    models = listOf(
+        "CreateCalendarItemRequest",
+        "UpdateCalendarItemRequest"
+    ),
+    mappings = mapOf(
+        "EntityModelCalendarItemDto" to "com.klabis.calendar.infrastructure.restapi.CalendarItemDto",
+        "EntityModelIcalTokenResponse" to "com.klabis.calendar.infrastructure.restapi.IcalTokenResponse",
+        // Collection, not List — see the event-types block above for why List is unusable here.
+        "CollectionModelEntityModelCalendarItemDto" to "java.util.Collection<com.klabis.calendar.infrastructure.restapi.CalendarItemDto>"
+    ),
+    extraImportMappings = mapOf(
+        "CollectionModelEntityModelCalendarItemDto" to "java.util.Collection"
+    )
+)

--- a/backend/src/main/java/com/klabis/calendar/infrastructure/restapi/CalendarController.java
+++ b/backend/src/main/java/com/klabis/calendar/infrastructure/restapi/CalendarController.java
@@ -5,10 +5,10 @@ import com.klabis.calendar.application.CalendarManagementPort;
 import com.klabis.calendar.domain.CalendarItem;
 import com.klabis.calendar.domain.EventCalendarItem;
 import com.klabis.common.mvc.MvcComponent;
+import com.klabis.common.ui.HalResponseContext;
 import com.klabis.common.ui.ModelWithDomainPostprocessor;
 import com.klabis.common.ui.RootModel;
 import com.klabis.common.users.Authority;
-import com.klabis.common.users.HasAuthority;
 import com.klabis.events.EventId;
 import com.klabis.events.infrastructure.restapi.EventController;
 import com.klabis.members.ActingUser;
@@ -19,34 +19,35 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
-import org.jspecify.annotations.Nullable;
 import org.springframework.data.domain.Sort;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.IanaLinkRelations;
+import org.springframework.hateoas.Link;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.server.ExposesResourceFor;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
+import java.net.URI;
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
 import static com.klabis.common.ui.HalFormsSupport.*;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @RestController
-@RequestMapping(value = "/api/calendar-items", produces = MediaTypes.HAL_FORMS_JSON_VALUE)
+@RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)
 @Tag(name = "Calendar", description = "Calendar item management API")
 @PrimaryAdapter
 @ExposesResourceFor(CalendarItem.class)
 @SecurityRequirement(name = "KlabisAuth", scopes = {Authority.CALENDAR_SCOPE})
-class CalendarController {
+class CalendarController implements CalendarApi {
 
     private final CalendarManagementPort calendarManagementService;
 
@@ -54,7 +55,6 @@ class CalendarController {
         this.calendarManagementService = calendarManagementService;
     }
 
-    @GetMapping
     @Operation(
             summary = "List calendar items with date range filtering",
             description = """
@@ -68,17 +68,16 @@ class CalendarController {
     )
     @ApiResponse(responseCode = "200", description = "List of calendar items retrieved successfully")
     @ApiResponse(responseCode = "400", description = "Date range exceeds 366 days or invalid sort field")
-    public ResponseEntity<CollectionModel<EntityModel<CalendarItemDto>>> listCalendarItems(
+    @Override
+    public ResponseEntity<Collection<CalendarItemDto>> listCalendarItems(
             @Parameter(description = "Start date for filtering (ISO DATE format, defaults to first day of current month)")
-            @RequestParam(required = false)
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            LocalDate startDate,
             @Parameter(description = "End date for filtering (ISO DATE format, defaults to last day of current month)")
-            @RequestParam(required = false)
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            LocalDate endDate,
             @Parameter(description = "Sorting parameters (default: startDate,asc)")
-            @RequestParam(defaultValue = "startDate,asc") String sort,
+            String sort,
             @Parameter(description = "When true, restricts results to EVENT_DATE items for events where the current user is a participant or coordinator")
-            @RequestParam(required = false) Boolean mySchedule,
+            Boolean mySchedule,
             @ActingUser CurrentUserData currentUser) {
 
         LocalDate effectiveStartDate = startDate != null ? startDate : getCurrentMonthFirstDay();
@@ -89,35 +88,13 @@ class CalendarController {
         boolean myScheduleRequested = Boolean.TRUE.equals(mySchedule);
         MemberId myScheduleMemberId = myScheduleRequested && currentUser != null ? currentUser.memberId() : null;
 
-        List<EntityModel<CalendarItemDto>> items = calendarManagementService
-                .listCalendarItems(effectiveStartDate, effectiveEndDate, sortObj, myScheduleRequested, myScheduleMemberId)
-                .stream().map(calendarItem -> entityModelWithDomain(toDto(calendarItem), calendarItem)).toList();
+        List<CalendarItem> calendarItems = calendarManagementService
+                .listCalendarItems(effectiveStartDate, effectiveEndDate, sortObj, myScheduleRequested, myScheduleMemberId);
 
-        CollectionModel<EntityModel<CalendarItemDto>> collectionModel = CollectionModel.of(items);
+        Collection<CalendarItemDto> payload = calendarItems.stream().map(this::toDto).toList();
 
-        klabisLinkTo(methodOn(CalendarController.class).listCalendarItems(effectiveStartDate, effectiveEndDate, sort, mySchedule, null))
-                .ifPresent(selfLinkBuilder -> collectionModel.add(selfLinkBuilder.withSelfRel()
-                        .andAffordances(klabisAfford(methodOn(CalendarController.class).createCalendarItem(null)))));
-
-        addMonthNavigationLinks(collectionModel, effectiveStartDate, effectiveEndDate, sort, mySchedule);
-
-        return ResponseEntity.ok(collectionModel);
-    }
-
-    private void addMonthNavigationLinks(CollectionModel<EntityModel<CalendarItemDto>> collectionModel,
-                                          LocalDate currentStartDate,
-                                          LocalDate currentEndDate,
-                                          String sort,
-                                          @Nullable Boolean mySchedule) {
-        LocalDate nextMonthStart = currentStartDate.plusMonths(1).withDayOfMonth(1);
-        LocalDate nextMonthEnd = nextMonthStart.withDayOfMonth(nextMonthStart.lengthOfMonth());
-        klabisLinkTo(methodOn(CalendarController.class).listCalendarItems(nextMonthStart, nextMonthEnd, sort, mySchedule, null))
-                .ifPresent(link -> collectionModel.add(link.withRel("next")));
-
-        LocalDate prevMonthStart = currentStartDate.minusMonths(1).withDayOfMonth(1);
-        LocalDate prevMonthEnd = prevMonthStart.withDayOfMonth(prevMonthStart.lengthOfMonth());
-        klabisLinkTo(methodOn(CalendarController.class).listCalendarItems(prevMonthStart, prevMonthEnd, sort, mySchedule, null))
-                .ifPresent(link -> collectionModel.add(link.withRel("prev")));
+        HalResponseContext.setDomainList(calendarItems);
+        return ResponseEntity.ok(payload);
     }
 
     private Sort parseAndValidateSort(String sort) {
@@ -147,23 +124,22 @@ class CalendarController {
         return Sort.by(direction, field);
     }
 
-    @GetMapping("/{id}")
     @Operation(
             summary = "Get calendar item by ID",
             description = "Retrieves detailed calendar item information by ID. " +
                           "Returns HATEOAS links based on whether the item is manually created or event-linked."
     )
     @ApiResponse(responseCode = "200", description = "Calendar item found")
-    public ResponseEntity<EntityModel<CalendarItemDto>> getCalendarItem(
-            @Parameter(description = "Calendar item UUID") @PathVariable UUID id) {
+    @Override
+    public ResponseEntity<CalendarItemDto> getCalendarItem(
+            @Parameter(description = "Calendar item UUID") UUID id) {
 
         CalendarItem calendarItem = calendarManagementService.getCalendarItem(new CalendarItemId(id));
 
-        return ResponseEntity.ok(entityModelWithDomain(toDto(calendarItem), calendarItem));
+        HalResponseContext.setDomain(calendarItem);
+        return ResponseEntity.ok(toDto(calendarItem));
     }
 
-    @PostMapping(consumes = "application/json")
-    @HasAuthority(Authority.CALENDAR_MANAGE)
     @Operation(
             summary = "Create a new manual calendar item",
             description = "Creates a new manual calendar item (not linked to an event). " +
@@ -171,19 +147,19 @@ class CalendarController {
                           "Returns Location header pointing to the created resource."
     )
     @ApiResponse(responseCode = "201", description = "Calendar item successfully created")
+    @Override
     public ResponseEntity<Void> createCalendarItem(
-            @Parameter(description = "Calendar item creation data")
-            @Valid @RequestBody CalendarItem.CreateCalendarItem command) {
+            @Parameter(description = "Calendar item creation data") CreateCalendarItemRequest request) {
 
-        CalendarItem created = calendarManagementService.createCalendarItem(normalizeDescription(command));
+        CalendarItem created = calendarManagementService.createCalendarItem(toCommand(request));
 
         return ResponseEntity
-                .created(linkTo(methodOn(CalendarController.class).getCalendarItem(created.getId().value())).toUri())
+                .created(klabisLinkTo(methodOn(CalendarController.class).getCalendarItem(created.getId().value()))
+                        .map(link -> link.toUri())
+                        .orElseGet(() -> URI.create("/api/calendar-items/" + created.getId().value())))
                 .build();
     }
 
-    @PutMapping(value = "/{id}", consumes = "application/json")
-    @HasAuthority(Authority.CALENDAR_MANAGE)
     @Operation(
             summary = "Update a manual calendar item",
             description = """
@@ -193,30 +169,29 @@ class CalendarController {
     )
     @ApiResponse(responseCode = "204", description = "Calendar item successfully updated")
     @ApiResponse(responseCode = "400", description = "Cannot update event-linked calendar item")
+    @Override
     public ResponseEntity<Void> updateCalendarItem(
-            @Parameter(description = "Calendar item UUID") @PathVariable UUID id,
-            @Parameter(description = "Calendar item update data") @Valid @RequestBody CalendarItem.UpdateCalendarItem command) {
+            @Parameter(description = "Calendar item UUID") UUID id,
+            @Parameter(description = "Calendar item update data") UpdateCalendarItemRequest request) {
 
-        calendarManagementService.updateCalendarItem(new CalendarItemId(id), normalizeDescription(command));
+        calendarManagementService.updateCalendarItem(new CalendarItemId(id), toCommand(request));
         return ResponseEntity.noContent().build();
     }
 
-    private static CalendarItem.CreateCalendarItem normalizeDescription(CalendarItem.CreateCalendarItem command) {
-        if (command.description() != null && command.description().isBlank()) {
-            return new CalendarItem.CreateCalendarItem(command.name(), null, command.startDate(), command.endDate());
-        }
-        return command;
+    private static CalendarItem.CreateCalendarItem toCommand(CreateCalendarItemRequest request) {
+        String description = normalizeDescription(request.description());
+        return new CalendarItem.CreateCalendarItem(request.name(), description, request.startDate(), request.endDate());
     }
 
-    private static CalendarItem.UpdateCalendarItem normalizeDescription(CalendarItem.UpdateCalendarItem command) {
-        if (command.description() != null && command.description().isBlank()) {
-            return new CalendarItem.UpdateCalendarItem(command.name(), null, command.startDate(), command.endDate());
-        }
-        return command;
+    private static CalendarItem.UpdateCalendarItem toCommand(UpdateCalendarItemRequest request) {
+        String description = normalizeDescription(request.description());
+        return new CalendarItem.UpdateCalendarItem(request.name(), description, request.startDate(), request.endDate());
     }
 
-    @DeleteMapping("/{id}")
-    @HasAuthority(Authority.CALENDAR_MANAGE)
+    private static String normalizeDescription(String description) {
+        return description != null && description.isBlank() ? null : description;
+    }
+
     @Operation(
             summary = "Delete a manual calendar item",
             description = "Deletes a manual calendar item. " +
@@ -225,8 +200,9 @@ class CalendarController {
     )
     @ApiResponse(responseCode = "204", description = "Calendar item successfully deleted")
     @ApiResponse(responseCode = "400", description = "Cannot delete event-linked calendar item")
+    @Override
     public ResponseEntity<Void> deleteCalendarItem(
-            @Parameter(description = "Calendar item UUID") @PathVariable UUID id) {
+            @Parameter(description = "Calendar item UUID") UUID id) {
 
         calendarManagementService.deleteCalendarItem(new CalendarItemId(id));
         return ResponseEntity.noContent().build();
@@ -278,6 +254,59 @@ class CalendarItemPostprocessor extends ModelWithDomainPostprocessor<CalendarIte
         LocalDate today = LocalDate.now();
         klabisLinkTo(methodOn(CalendarController.class).listCalendarItems(today.withDayOfMonth(1), today.withDayOfMonth(today.lengthOfMonth()), "startDate,asc", null, null))
                 .ifPresent(link -> dtoModel.add(link.withRel("collection")));
+    }
+}
+
+/**
+ * Adds the collection-level create affordance plus month navigation links. The self link itself is
+ * built by {@code HalResponseBodyAdvice} from the current request (preserving startDate, endDate,
+ * sort and mySchedule), so this processor only contributes to it and adds next/prev.
+ */
+@MvcComponent
+class CalendarItemListPostprocessor
+        implements RepresentationModelProcessor<CollectionModel<EntityModel<CalendarItemDto>>> {
+
+    @Override
+    public CollectionModel<EntityModel<CalendarItemDto>> process(
+            CollectionModel<EntityModel<CalendarItemDto>> model) {
+        model.mapLink(IanaLinkRelations.SELF, selfLink -> (Link) selfLink
+                .andAffordances(klabisAfford(methodOn(CalendarController.class).createCalendarItem(null))));
+
+        model.getLink(IanaLinkRelations.SELF)
+                .map(Link::getHref)
+                .ifPresent(selfHref -> addMonthNavigationLinks(model, selfHref));
+
+        return model;
+    }
+
+    private void addMonthNavigationLinks(CollectionModel<EntityModel<CalendarItemDto>> model, String selfHref) {
+        var uriComponents = org.springframework.web.util.UriComponentsBuilder.fromUriString(selfHref).build();
+        var params = uriComponents.getQueryParams();
+
+        LocalDate currentStartDate = params.getFirst("startDate") != null
+                ? LocalDate.parse(params.getFirst("startDate")) : getCurrentMonthFirstDay();
+        LocalDate currentEndDate = params.getFirst("endDate") != null
+                ? LocalDate.parse(params.getFirst("endDate")) : getCurrentMonthLastDay();
+        String sort = params.getFirst("sort") != null ? params.getFirst("sort") : "startDate,asc";
+        Boolean mySchedule = params.getFirst("mySchedule") != null ? Boolean.valueOf(params.getFirst("mySchedule")) : null;
+
+        LocalDate nextMonthStart = currentStartDate.plusMonths(1).withDayOfMonth(1);
+        LocalDate nextMonthEnd = nextMonthStart.withDayOfMonth(nextMonthStart.lengthOfMonth());
+        klabisLinkTo(methodOn(CalendarController.class).listCalendarItems(nextMonthStart, nextMonthEnd, sort, mySchedule, null))
+                .ifPresent(link -> model.add(link.withRel("next")));
+
+        LocalDate prevMonthStart = currentStartDate.minusMonths(1).withDayOfMonth(1);
+        LocalDate prevMonthEnd = prevMonthStart.withDayOfMonth(prevMonthStart.lengthOfMonth());
+        klabisLinkTo(methodOn(CalendarController.class).listCalendarItems(prevMonthStart, prevMonthEnd, sort, mySchedule, null))
+                .ifPresent(link -> model.add(link.withRel("prev")));
+    }
+
+    private LocalDate getCurrentMonthFirstDay() {
+        return LocalDate.now().withDayOfMonth(1);
+    }
+
+    private LocalDate getCurrentMonthLastDay() {
+        return LocalDate.now().withDayOfMonth(LocalDate.now().lengthOfMonth());
     }
 }
 

--- a/backend/src/main/java/com/klabis/calendar/infrastructure/restapi/IcalTokenController.java
+++ b/backend/src/main/java/com/klabis/calendar/infrastructure/restapi/IcalTokenController.java
@@ -1,6 +1,8 @@
 package com.klabis.calendar.infrastructure.restapi;
 
 import com.klabis.calendar.application.IcalTokenPort;
+import com.klabis.common.mvc.MvcComponent;
+import com.klabis.common.ui.HalResponseContext;
 import com.klabis.common.users.UserId;
 import com.klabis.members.ActingUser;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,9 +13,8 @@ import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,10 +26,10 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @PrimaryAdapter
 @RestController
-@RequestMapping(value = "/api/me/ical-token", produces = MediaTypes.HAL_FORMS_JSON_VALUE)
+@RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)
 @Tag(name = "Calendar Feed Token", description = "iCalendar feed token management for the current user")
 @SecurityRequirement(name = "KlabisAuth", scopes = {"openid"})
-class IcalTokenController {
+class IcalTokenController implements IcalTokenApi {
 
     private final IcalTokenPort icalTokenPort;
     private final String baseUrl;
@@ -40,7 +41,6 @@ class IcalTokenController {
         this.baseUrl = baseUrl;
     }
 
-    @GetMapping
     @Operation(
             summary = "Get iCal feed token state",
             description = """
@@ -52,20 +52,15 @@ class IcalTokenController {
                     """
     )
     @ApiResponse(responseCode = "200", description = "Token state returned")
-    ResponseEntity<EntityModel<IcalTokenResponse>> getTokenState(@ActingUser UserId currentUserId) {
-        return icalTokenPort.getTokenState(currentUserId)
-                .map(state -> {
-                    String maskedUrl = buildMaskedSubscribeUrl(state.tokenLookup());
-                    IcalTokenResponse response = new IcalTokenResponse(maskedUrl, state.lastSetAt());
-                    return ResponseEntity.ok(buildModel(response));
-                })
-                .orElseGet(() -> {
-                    IcalTokenResponse response = new IcalTokenResponse(null, null);
-                    return ResponseEntity.ok(buildModel(response));
-                });
+    @Override
+    public ResponseEntity<IcalTokenResponse> getTokenState(@ActingUser UserId currentUserId) {
+        IcalTokenResponse response = icalTokenPort.getTokenState(currentUserId)
+                .map(state -> new IcalTokenResponse(buildMaskedSubscribeUrl(state.tokenLookup()), state.lastSetAt()))
+                .orElseGet(() -> new IcalTokenResponse(null, null));
+        HalResponseContext.setDomain(response);
+        return ResponseEntity.ok(response);
     }
 
-    @PostMapping
     @Operation(
             summary = "Generate or regenerate iCal feed token",
             description = """
@@ -76,21 +71,12 @@ class IcalTokenController {
                     """
     )
     @ApiResponse(responseCode = "200", description = "New token generated; full subscribe URL returned once")
-    ResponseEntity<EntityModel<IcalTokenResponse>> generateToken(@ActingUser UserId currentUserId) {
+    @Override
+    public ResponseEntity<IcalTokenResponse> generateToken(@ActingUser UserId currentUserId) {
         IcalTokenPort.GenerateResult result = icalTokenPort.generateOrRotate(currentUserId);
-        String fullUrl = buildSubscribeUrl(result.rawToken());
-        IcalTokenResponse response = new IcalTokenResponse(fullUrl, result.lastSetAt());
-        return ResponseEntity.ok(buildModel(response));
-    }
-
-    private EntityModel<IcalTokenResponse> buildModel(IcalTokenResponse response) {
-        EntityModel<IcalTokenResponse> model = EntityModel.of(response);
-        klabisLinkTo(methodOn(IcalTokenController.class).getTokenState(null))
-                .ifPresent(link -> model.add(
-                        link.withSelfRel()
-                                .andAffordances(klabisAfford(methodOn(IcalTokenController.class).generateToken(null)))
-                ));
-        return model;
+        IcalTokenResponse response = new IcalTokenResponse(buildSubscribeUrl(result.rawToken()), result.lastSetAt());
+        HalResponseContext.setDomain(response);
+        return ResponseEntity.ok(response);
     }
 
     private String buildSubscribeUrl(String rawToken) {
@@ -106,3 +92,17 @@ class IcalTokenController {
 }
 
 record IcalTokenResponse(String url, Instant lastSetAt) {}
+
+@MvcComponent
+class IcalTokenResponsePostprocessor implements RepresentationModelProcessor<EntityModel<IcalTokenResponse>> {
+
+    @Override
+    public EntityModel<IcalTokenResponse> process(EntityModel<IcalTokenResponse> model) {
+        klabisLinkTo(methodOn(IcalTokenController.class).getTokenState(null))
+                .ifPresent(link -> model.add(
+                        link.withSelfRel()
+                                .andAffordances(klabisAfford(methodOn(IcalTokenController.class).generateToken(null)))
+                ));
+        return model;
+    }
+}

--- a/backend/src/main/java/com/klabis/finance/infrastructure/restapi/MemberAccountController.java
+++ b/backend/src/main/java/com/klabis/finance/infrastructure/restapi/MemberAccountController.java
@@ -1,9 +1,8 @@
 package com.klabis.finance.infrastructure.restapi;
 
 import com.klabis.common.mvc.MvcComponent;
+import com.klabis.common.ui.HalResponseContext;
 import com.klabis.common.ui.ModelWithDomainPostprocessor;
-import com.klabis.common.users.Authority;
-import com.klabis.common.users.HasAuthority;
 import com.klabis.finance.application.ChargePort;
 import com.klabis.finance.application.DepositPort;
 import com.klabis.finance.application.MemberAccountNotFoundException;
@@ -19,130 +18,120 @@ import com.klabis.members.ActingUser;
 import com.klabis.members.CurrentUserData;
 import com.klabis.members.MemberId;
 import com.klabis.members.infrastructure.restapi.MemberController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.data.web.PageableDefault;
-import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.EntityModel;
-import org.springframework.hateoas.Link;
 import org.springframework.hateoas.MediaTypes;
-import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.math.BigDecimal;
 import java.net.URI;
 import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 
-import static com.klabis.common.ui.HalFormsSupport.entityModelWithDomain;
 import static com.klabis.common.ui.HalFormsSupport.klabisAfford;
 import static com.klabis.common.ui.HalFormsSupport.klabisLinkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @PrimaryAdapter
 @RestController
-@RequestMapping(value = "/api/members/{memberId}/account", produces = MediaTypes.HAL_FORMS_JSON_VALUE)
+@RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)
 @Tag(name = "Finance", description = "Member financial account API")
-class MemberAccountController {
+class MemberAccountController implements FinanceApi {
 
     private final DepositPort depositPort;
     private final ChargePort chargePort;
     private final ReversePort reversePort;
     private final MemberAccountRepository memberAccountRepository;
     private final TransactionQueryPort transactionQueryPort;
-    private final PagedResourcesAssembler<TransactionWithReversal> pagedResourcesAssembler;
 
     MemberAccountController(DepositPort depositPort, ChargePort chargePort,
                             ReversePort reversePort,
                             MemberAccountRepository memberAccountRepository,
-                            TransactionQueryPort transactionQueryPort,
-                            PagedResourcesAssembler<TransactionWithReversal> pagedResourcesAssembler) {
+                            TransactionQueryPort transactionQueryPort) {
         this.depositPort = depositPort;
         this.chargePort = chargePort;
         this.reversePort = reversePort;
         this.memberAccountRepository = memberAccountRepository;
         this.transactionQueryPort = transactionQueryPort;
-        this.pagedResourcesAssembler = pagedResourcesAssembler;
     }
 
-    @GetMapping
+    @Operation(summary = "Get a member's finance account balance",
+            description = "Returns the current balance of a member's finance account.")
+    @ApiResponse(responseCode = "200", description = "Account found")
     @Transactional(readOnly = true)
-    public ResponseEntity<EntityModel<MemberAccountResource>> getAccount(
-            @PathVariable UUID memberId,
+    @Override
+    public ResponseEntity<MemberAccountResource> getAccount(
+            @Parameter(description = "Member UUID") UUID memberId,
             @ActingUser CurrentUserData currentUser) {
         MemberId id = new MemberId(memberId);
-        checkAccountAccess(id, currentUser);
         Money balance = memberAccountRepository.findBalanceById(id)
                 .orElseThrow(() -> new MemberAccountNotFoundException(id));
         MemberAccountResource resource = MemberAccountResource.fromBalance(id, balance);
-        return ResponseEntity.ok(entityModelWithDomain(resource, id));
+        HalResponseContext.setDomain(id);
+        return ResponseEntity.ok(resource);
     }
 
-    @GetMapping("/transactions")
+    @Operation(summary = "List a member's account transactions",
+            description = "Paginated, filterable transaction history for a member's finance account. "
+                          + "Supports filtering by occurred-date range and transaction type.")
+    @ApiResponse(responseCode = "200", description = "Paginated transaction history")
     @Transactional(readOnly = true)
-    public ResponseEntity<PagedModel<EntityModel<TransactionResource>>> listTransactions(
-            @PathVariable UUID memberId,
-            @ActingUser CurrentUserData currentUser,
-            @RequestParam(required = false) LocalDate occurredAtFrom,
-            @RequestParam(required = false) LocalDate occurredAtTo,
-            @RequestParam(required = false) TransactionType type,
-            @PageableDefault(size = 20, sort = "occurredAt", direction = Sort.Direction.DESC)
-            Pageable pageable) {
-        MemberId id = new MemberId(memberId);
-        checkAccountAccess(id, currentUser);
-
-        Page<TransactionWithReversal> page = transactionQueryPort.findTransactionsWithReversals(
-                new TransactionQueryPort.TransactionQuery(id, occurredAtFrom, occurredAtTo, type, pageable));
-
-        boolean canReverse = currentUser.hasAuthority(Authority.FINANCE_MANAGE);
-        Optional<Link> accountLink = FinanceLinks.accountLink(memberId);
-
-        PagedModel<EntityModel<TransactionResource>> model = pagedResourcesAssembler.toModel(
-                page,
-                twr -> {
-                    EntityModel<TransactionResource> item = EntityModel.of(TransactionResource.from(twr.transaction()));
-                    UUID reversedByTxId = twr.reversedBy().map(TransactionId::value).orElse(null);
-                    addTransactionLinks(item, memberId, twr.transaction(), reversedByTxId, canReverse, accountLink);
-                    return item;
-                });
-        return ResponseEntity.ok(model);
-    }
-
-    @GetMapping("/transactions/{txId}")
-    @Transactional(readOnly = true)
-    public ResponseEntity<EntityModel<TransactionResource>> getTransaction(
-            @PathVariable UUID memberId,
-            @PathVariable UUID txId,
+    @Override
+    public ResponseEntity<Page<TransactionResource>> listTransactions(
+            @Parameter(description = "Member UUID") UUID memberId,
+            @Parameter(description = "Only include transactions occurred on or after this date") LocalDate occurredAtFrom,
+            @Parameter(description = "Only include transactions occurred on or before this date") LocalDate occurredAtTo,
+            @Parameter(description = "Transaction type filter: DEPOSIT, CHARGE, OTHER") String type,
+            @Parameter(description = "Pagination parameters: page, size, sort") Pageable pageable,
             @ActingUser CurrentUserData currentUser) {
         MemberId id = new MemberId(memberId);
-        checkAccountAccess(id, currentUser);
-        Transaction tx = transactionQueryPort.findTransaction(id, new TransactionId(txId));
+        TransactionType typeFilter = type != null ? TransactionType.valueOf(type) : null;
 
-        Transaction reversal = memberAccountRepository.findReversalOf(tx.getId()).orElse(null);
-        UUID reversedByTxId = reversal != null ? reversal.getId().value() : null;
+        Page<TransactionWithReversal> page = transactionQueryPort.findTransactionsWithReversals(
+                new TransactionQueryPort.TransactionQuery(id, occurredAtFrom, occurredAtTo, typeFilter, pageable));
 
-        EntityModel<TransactionResource> model = EntityModel.of(TransactionResource.from(tx));
-        addTransactionLinks(model, memberId, tx, reversedByTxId,
-                currentUser.hasAuthority(Authority.FINANCE_MANAGE),
-                FinanceLinks.accountLink(memberId));
-        return ResponseEntity.ok(model);
+        HalResponseContext.setDomainList(page.getContent().stream()
+                .map(twr -> new AccountTransaction(id, twr))
+                .toList());
+        return ResponseEntity.ok(page.map(twr -> TransactionResource.from(twr.transaction())));
     }
 
-    @PostMapping("/transactions")
-    @HasAuthority(Authority.FINANCE_MANAGE)
+    @Operation(summary = "Get a single account transaction",
+            description = "Returns a single transaction on a member's finance account.")
+    @ApiResponse(responseCode = "200", description = "Transaction found")
+    @Transactional(readOnly = true)
+    @Override
+    public ResponseEntity<TransactionResource> getTransaction(
+            @Parameter(description = "Member UUID") UUID memberId,
+            @Parameter(description = "Transaction UUID") UUID txId,
+            @ActingUser CurrentUserData currentUser) {
+        MemberId id = new MemberId(memberId);
+        Transaction tx = transactionQueryPort.findTransaction(id, new TransactionId(txId));
+
+        TransactionWithReversal twr = memberAccountRepository.findReversalOf(tx.getId())
+                .map(reversal -> TransactionWithReversal.withReversal(tx, reversal.getId()))
+                .orElseGet(() -> TransactionWithReversal.withoutReversal(tx));
+
+        HalResponseContext.setDomain(new AccountTransaction(id, twr));
+        return ResponseEntity.ok(TransactionResource.from(tx));
+    }
+
+    @Operation(summary = "Record a deposit on a member's account",
+            description = "Records a deposit transaction, crediting the member's account balance.")
+    @ApiResponse(responseCode = "201", description = "Deposit recorded")
+    @Override
     public ResponseEntity<Void> deposit(
-            @PathVariable UUID memberId,
-            @Valid @RequestBody DepositRequest request,
+            @Parameter(description = "Member UUID") UUID memberId,
+            DepositRequest request,
             @ActingUser com.klabis.common.users.UserId currentUserId) {
         LocalDate occurredAt = request.occurredAt() != null ? request.occurredAt() : LocalDate.now();
         Transaction tx = depositPort.deposit(new DepositPort.DepositCommand(
@@ -150,11 +139,13 @@ class MemberAccountController {
         return ResponseEntity.created(buildTransactionUri(memberId, tx.getId().value())).build();
     }
 
-    @PostMapping("/transactions/charge")
-    @HasAuthority(Authority.FINANCE_MANAGE)
+    @Operation(summary = "Record a charge on a member's account",
+            description = "Records a charge transaction, debiting the member's account balance.")
+    @ApiResponse(responseCode = "201", description = "Charge recorded")
+    @Override
     public ResponseEntity<Void> charge(
-            @PathVariable UUID memberId,
-            @Valid @RequestBody ChargeRequest request,
+            @Parameter(description = "Member UUID") UUID memberId,
+            ChargeRequest request,
             @ActingUser com.klabis.common.users.UserId currentUserId) {
         LocalDate occurredAt = request.occurredAt() != null ? request.occurredAt() : LocalDate.now();
         Transaction tx = chargePort.charge(new ChargePort.ChargeCommand(
@@ -162,12 +153,15 @@ class MemberAccountController {
         return ResponseEntity.created(buildTransactionUri(memberId, tx.getId().value())).build();
     }
 
-    @PostMapping("/transactions/{txId}/reverse")
-    @HasAuthority(Authority.FINANCE_MANAGE)
+    @Operation(summary = "Reverse an account transaction",
+            description = "Creates a reversal transaction offsetting the original. "
+                          + "Fails with 409 when the transaction has already been reversed.")
+    @ApiResponse(responseCode = "201", description = "Reversal recorded")
+    @Override
     public ResponseEntity<Void> reverse(
-            @PathVariable UUID memberId,
-            @PathVariable UUID txId,
-            @Valid @RequestBody ReverseRequest request,
+            @Parameter(description = "Member UUID") UUID memberId,
+            @Parameter(description = "Transaction UUID") UUID txId,
+            ReverseRequest request,
             @ActingUser com.klabis.common.users.UserId currentUserId) {
         LocalDate occurredAt = request.occurredAt() != null ? request.occurredAt() : LocalDate.now();
         Transaction tx = reversePort.reverse(new ReversePort.ReverseCommand(
@@ -175,72 +169,18 @@ class MemberAccountController {
         return ResponseEntity.created(buildTransactionUri(memberId, tx.getId().value())).build();
     }
 
-    private void checkAccountAccess(MemberId memberId, CurrentUserData currentUser) {
-        boolean isOwner = currentUser.memberId() != null && currentUser.memberId().equals(memberId);
-        boolean hasFinanceManage = currentUser.hasAuthority(Authority.FINANCE_MANAGE);
-        if (!isOwner && !hasFinanceManage) {
-            throw new AccessDeniedException(
-                    "Access denied: not account owner and missing FINANCE:MANAGE authority");
-        }
-    }
-
-    private void addTransactionLinks(EntityModel<TransactionResource> model, UUID memberId,
-                                     Transaction tx, UUID reversedByTxId,
-                                     boolean canReverse, Optional<Link> accountLink) {
-        UUID txId = tx.getId().value();
-        klabisLinkTo(methodOn(MemberAccountController.class).getTransaction(memberId, txId, null))
-                .map(link -> {
-                    if (reversedByTxId == null && !tx.isReversal() && canReverse) {
-                        return link.withSelfRel()
-                                .andAffordances(klabisAfford(
-                                        methodOn(MemberAccountController.class).reverse(memberId, txId, null, null)));
-                    }
-                    return link.withSelfRel();
-                })
-                .ifPresent(model::add);
-
-        if (reversedByTxId != null) {
-            klabisLinkTo(methodOn(MemberAccountController.class).getTransaction(memberId, reversedByTxId, null))
-                    .ifPresent(link -> model.add(link.withRel("reversedBy")));
-        }
-
-        if (tx.isReversal()) {
-            UUID originalTxId = tx.getReversesTransactionId().value();
-            klabisLinkTo(methodOn(MemberAccountController.class).getTransaction(memberId, originalTxId, null))
-                    .ifPresent(link -> model.add(link.withRel("reverses")));
-        }
-
-        klabisLinkTo(methodOn(MemberController.class).getMember(tx.getRecordedBy().uuid(), null))
-                .ifPresent(link -> model.add(link.withRel("recordedBy")));
-
-        accountLink.ifPresent(model::add);
-    }
-
-    private URI buildTransactionUri(UUID memberId, UUID txId) {
+    private static URI buildTransactionUri(UUID memberId, UUID txId) {
         return klabisLinkTo(methodOn(MemberAccountController.class).getTransaction(memberId, txId, null))
                 .map(link -> link.toUri())
                 .orElseGet(() -> URI.create("/api/members/" + memberId + "/account/transactions/" + txId));
     }
+}
 
-    record DepositRequest(
-            @NotNull @Positive BigDecimal amount,
-            LocalDate occurredAt,
-            String note
-    ) {
-    }
-
-    record ChargeRequest(
-            @NotNull @Positive BigDecimal amount,
-            LocalDate occurredAt,
-            String note
-    ) {
-    }
-
-    record ReverseRequest(
-            String note,
-            LocalDate occurredAt
-    ) {
-    }
+/**
+ * Transaction.class carries no memberId of its own — the path parameter is the only source of
+ * truth for which account it belongs to — so the postprocessor needs both paired together.
+ */
+record AccountTransaction(MemberId memberId, TransactionWithReversal transactionWithReversal) {
 }
 
 @MvcComponent
@@ -257,10 +197,50 @@ class MemberAccountPostprocessor extends ModelWithDomainPostprocessor<MemberAcco
                 .ifPresent(model::add);
 
         klabisLinkTo(methodOn(MemberAccountController.class).listTransactions(
-                memberId.uuid(), null, null, null, null, Pageable.unpaged()))
+                memberId.uuid(), null, null, null, Pageable.unpaged(), null))
                 .ifPresent(link -> model.add(link.withRel("transactions")));
 
         klabisLinkTo(methodOn(MemberController.class).getMember(memberId.uuid(), null))
                 .ifPresent(link -> model.add(link.withRel("accountOwner")));
+    }
+}
+
+@MvcComponent
+class TransactionPostprocessor extends ModelWithDomainPostprocessor<TransactionResource, AccountTransaction> {
+
+    @Override
+    public void process(EntityModel<TransactionResource> model, AccountTransaction accountTransaction) {
+        TransactionWithReversal twr = accountTransaction.transactionWithReversal();
+        Transaction tx = twr.transaction();
+        UUID memberId = accountTransaction.memberId().uuid();
+        UUID txId = tx.getId().value();
+        boolean canReverse = FinanceSecurityHelper.callerHasFinanceManage();
+        Optional<UUID> reversedByTxId = twr.reversedBy().map(TransactionId::value);
+
+        klabisLinkTo(methodOn(MemberAccountController.class).getTransaction(memberId, txId, null))
+                .map(link -> {
+                    if (reversedByTxId.isEmpty() && !tx.isReversal() && canReverse) {
+                        return link.withSelfRel()
+                                .andAffordances(klabisAfford(
+                                        methodOn(MemberAccountController.class).reverse(memberId, txId, null, null)));
+                    }
+                    return link.withSelfRel();
+                })
+                .ifPresent(model::add);
+
+        reversedByTxId.ifPresent(id ->
+                klabisLinkTo(methodOn(MemberAccountController.class).getTransaction(memberId, id, null))
+                        .ifPresent(link -> model.add(link.withRel("reversedBy"))));
+
+        if (tx.isReversal()) {
+            UUID originalTxId = tx.getReversesTransactionId().value();
+            klabisLinkTo(methodOn(MemberAccountController.class).getTransaction(memberId, originalTxId, null))
+                    .ifPresent(link -> model.add(link.withRel("reverses")));
+        }
+
+        klabisLinkTo(methodOn(MemberController.class).getMember(tx.getRecordedBy().uuid(), null))
+                .ifPresent(link -> model.add(link.withRel("recordedBy")));
+
+        FinanceLinks.accountLink(memberId).ifPresent(model::add);
     }
 }

--- a/backend/src/test/java/com/klabis/finance/infrastructure/restapi/AccountRootLinkProcessorTest.java
+++ b/backend/src/test/java/com/klabis/finance/infrastructure/restapi/AccountRootLinkProcessorTest.java
@@ -1,11 +1,15 @@
 package com.klabis.finance.infrastructure.restapi;
 
 import com.klabis.common.security.KlabisJwtAuthenticationToken;
+import com.klabis.common.security.fieldsecurity.OwnershipResolver;
+import com.klabis.common.ui.HalFormsSupport;
 import com.klabis.common.ui.RootModel;
 import com.klabis.common.users.UserId;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
@@ -15,6 +19,7 @@ import java.util.Collections;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -23,9 +28,39 @@ class AccountRootLinkProcessorTest {
 
     private final AccountRootLinkProcessor processor = new AccountRootLinkProcessor();
 
+    // HalFormsSupport.INSTANCE is a static shared across the whole test JVM, set only by
+    // @PostConstruct on a real Spring context. Without wiring a real OwnershipResolver here, a
+    // leftover INSTANCE from a *different* test class's context (whose resolver bean isn't this
+    // test's concern) makes ownership checks fall through to false regardless of what this test
+    // asserts. Same pattern as AccountMemberDetailLinkProcessorTest in this package.
+    private Object previousInstance;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUpOwnershipResolver() throws Exception {
+        ObjectProvider<OwnershipResolver> ownershipResolverProvider = mock(ObjectProvider.class);
+        OwnershipResolver resolver = (ownerIdValue, authentication) -> {
+            UUID ownerId = (UUID) ownerIdValue;
+            return authentication instanceof KlabisJwtAuthenticationToken token
+                   && token.getMemberIdUuid().map(ownerId::equals).orElse(false);
+        };
+        when(ownershipResolverProvider.getIfAvailable()).thenReturn(resolver);
+
+        HalFormsSupport halFormsSupport = new HalFormsSupport(ownershipResolverProvider);
+        previousInstance = instanceField().get(null);
+        instanceField().set(null, halFormsSupport);
+    }
+
     @AfterEach
-    void clearSecurityContext() {
+    void clearSecurityContext() throws Exception {
+        instanceField().set(null, previousInstance);
         SecurityContextHolder.clearContext();
+    }
+
+    private static java.lang.reflect.Field instanceField() throws NoSuchFieldException {
+        java.lang.reflect.Field field = HalFormsSupport.class.getDeclaredField("INSTANCE");
+        field.setAccessible(true);
+        return field;
     }
 
     @Test
@@ -68,6 +103,10 @@ class AccountRootLinkProcessorTest {
         KlabisJwtAuthenticationToken token = mock(KlabisJwtAuthenticationToken.class);
         when(token.getMemberIdUuid()).thenReturn(java.util.Optional.of(memberId));
         when(token.hasMemberProfile()).thenReturn(true);
+        when(token.isAuthenticated()).thenReturn(true);
+        // Empty authorities: the account link must appear via ownership (@OwnerVisible/@OwnerId),
+        // not FINANCE:MANAGE — proves the ownership branch, not just the authority branch.
+        doReturn(Collections.emptyList()).when(token).getAuthorities();
 
         SecurityContext context = SecurityContextHolder.createEmptyContext();
         context.setAuthentication(token);

--- a/docs/openapi/spec/calendar.yaml
+++ b/docs/openapi/spec/calendar.yaml
@@ -1,0 +1,559 @@
+# Calendar module — the API surface of CalendarController, IcalTokenController and
+# IcalFeedController (calendar module).
+#
+# CalendarController manages calendar items (manual and event-linked). IcalTokenController manages
+# the current user's personal iCal feed token. IcalFeedController serves the actual iCalendar feed —
+# see the note on getMySchedule below for why it is documented rather than fully spec-first.
+#
+# All CALENDAR_MANAGE checks were plain @HasAuthority on the controller — no imperative
+# checkXxx()-style authorization was found in this module, so every operation maps directly to
+# x-klabis-authority with no x-klabis-owner-visible pairing.
+
+paths:
+
+  /api/calendar-items:
+    get:
+      operationId: listCalendarItems
+      tags: [Calendar]
+      summary: List calendar items with date range filtering
+      description: |
+        Retrieves a list of calendar items filtered by date range.
+        If dates not provided, defaults to current month.
+        Maximum date range is 1 year (366 days).
+        Default sort: startDate,asc. Allowed fields: id, name, startDate, endDate.
+        When mySchedule=true, returns only EVENT_DATE items linked to events where the current
+        user is an active participant or event coordinator.
+      security:
+        - KlabisAuth: [CALENDAR]
+      # No x-klabis-authority: reading the calendar requires authentication only. There is no
+      # CALENDAR:READ authority (Authority.java has CALENDAR_MANAGE alone), and the controller
+      # never restricted these reads — adding one here would change behaviour, not describe it.
+      x-spring-provide-args:
+        - '@com.klabis.members.ActingUser com.klabis.members.CurrentUserData currentUser'
+      parameters:
+        - name: startDate
+          in: query
+          description: Start date for filtering (ISO DATE format, defaults to first day of current month)
+          required: false
+          schema:
+            type: string
+            format: date
+        - name: endDate
+          in: query
+          description: End date for filtering (ISO DATE format, defaults to last day of current month)
+          required: false
+          schema:
+            type: string
+            format: date
+        - name: sort
+          in: query
+          description: 'Sorting parameters (default: startDate,asc)'
+          required: false
+          schema:
+            type: string
+            default: startDate,asc
+        - name: mySchedule
+          in: query
+          description: |
+            When true, restricts results to EVENT_DATE items for events where the current user is
+            a participant or coordinator
+          required: false
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: List of calendar items retrieved successfully
+          content:
+            application/prs.hal-forms+json:
+              schema:
+                $ref: '#/components/schemas/CollectionModelEntityModelCalendarItemDto'
+          x-hal-links:
+            self:
+              description: This collection, with the current date-range, sort and mySchedule parameters
+            next:
+              description: Same range shifted forward by one month
+            prev:
+              description: Same range shifted back by one month
+          x-hal-templates:
+            createCalendarItem:
+              operation: createCalendarItem
+              description: Present only for callers with CALENDAR:MANAGE
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+
+    post:
+      operationId: createCalendarItem
+      tags: [Calendar]
+      summary: Create a new manual calendar item
+      description: |
+        Creates a new manual calendar item (not linked to an event). Manual items can be updated
+        and deleted. Returns Location header pointing to the created resource.
+      security:
+        - KlabisAuth: [CALENDAR]
+      x-klabis-authority: CALENDAR_MANAGE
+      requestBody:
+        required: true
+        x-codegen-request-body-name: request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCalendarItemRequest'
+      responses:
+        '201':
+          description: Calendar item successfully created
+          headers:
+            Location:
+              description: URI of the created calendar item
+              schema:
+                type: string
+                format: uri
+          content:
+            application/prs.hal-forms+json: {}
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+
+  /api/calendar-items/{id}:
+    get:
+      operationId: getCalendarItem
+      tags: [Calendar]
+      summary: Get calendar item by ID
+      description: |
+        Retrieves detailed calendar item information by ID. Returns HATEOAS links based on whether
+        the item is manually created or event-linked.
+      security:
+        - KlabisAuth: [CALENDAR]
+      # See listCalendarItems: authenticated-only, no CALENDAR:READ authority exists.
+      parameters:
+        - $ref: '#/components/parameters/CalendarItemIdParam'
+      responses:
+        '200':
+          description: Calendar item found
+          content:
+            application/prs.hal-forms+json:
+              schema:
+                $ref: '#/components/schemas/EntityModelCalendarItemDto'
+          x-hal-links:
+            self:
+              description: |
+                This calendar item. Event-linked items carry no update/delete affordances since
+                they are read-only.
+            event:
+              # No `operation:` yet — it points at getEvent in the events module, which is still
+              # code-first, so the bundler cannot resolve the operationId. Add
+              # `operation: getEvent` when events.yaml lands.
+              description: Present only for event-linked items — the event this item is derived from
+            collection:
+              operation: listCalendarItems
+              description: Back to the current month's calendar item list
+          x-hal-templates:
+            default:
+              operation: updateCalendarItem
+              description: Present only for manual items and callers with CALENDAR:MANAGE
+            deleteCalendarItem:
+              operation: deleteCalendarItem
+              description: Present only for manual items and callers with CALENDAR:MANAGE
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+
+    put:
+      operationId: updateCalendarItem
+      tags: [Calendar]
+      summary: Update a manual calendar item
+      description: |
+        Updates calendar item information. Only allowed for manual items (not event-linked).
+        Event-linked items are read-only and managed automatically.
+      security:
+        - KlabisAuth: [CALENDAR]
+      x-klabis-authority: CALENDAR_MANAGE
+      parameters:
+        - $ref: '#/components/parameters/CalendarItemIdParam'
+      requestBody:
+        required: true
+        x-codegen-request-body-name: request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateCalendarItemRequest'
+      responses:
+        '204':
+          description: Calendar item successfully updated
+          content:
+            application/prs.hal-forms+json: {}
+        '400':
+          description: Cannot update event-linked calendar item
+          content:
+            application/problem+json:
+              schema:
+                $ref: './_shared/problem.yaml#/components/schemas/ProblemDetail'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+
+    delete:
+      operationId: deleteCalendarItem
+      tags: [Calendar]
+      summary: Delete a manual calendar item
+      description: |
+        Deletes a manual calendar item. Only allowed for manual items (not event-linked).
+        Event-linked items are read-only and managed automatically.
+      security:
+        - KlabisAuth: [CALENDAR]
+      x-klabis-authority: CALENDAR_MANAGE
+      parameters:
+        - $ref: '#/components/parameters/CalendarItemIdParam'
+      responses:
+        '204':
+          description: Calendar item successfully deleted
+          content:
+            application/prs.hal-forms+json: {}
+        '400':
+          description: Cannot delete event-linked calendar item
+          content:
+            application/problem+json:
+              schema:
+                $ref: './_shared/problem.yaml#/components/schemas/ProblemDetail'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+
+  /api/me/ical-token:
+    get:
+      operationId: getTokenState
+      tags: [IcalToken]
+      summary: Get iCal feed token state
+      description: |
+        Returns the current iCal feed token state for the authenticated user.
+        If a token exists, returns the masked subscribe URL and the timestamp when the token was
+        last set. The URL is masked — the full raw token is never stored and can only be revealed
+        at generation time. Use the 'regenerate' affordance (POST) to create or rotate the token
+        and receive the full URL once. If no token exists, returns url=null.
+      security:
+        - KlabisAuth: [openid]
+      x-spring-provide-args:
+        - '@com.klabis.members.ActingUser com.klabis.common.users.UserId currentUserId'
+      responses:
+        '200':
+          description: Token state returned
+          content:
+            application/prs.hal-forms+json:
+              schema:
+                $ref: '#/components/schemas/EntityModelIcalTokenResponse'
+          x-hal-links:
+            self:
+              description: This token state
+          x-hal-templates:
+            default:
+              operation: generateToken
+              description: Generates or rotates the token; the full subscribe URL is returned once
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+
+    post:
+      operationId: generateToken
+      tags: [IcalToken]
+      summary: Generate or regenerate iCal feed token
+      description: |
+        Generates a new iCal feed token for the authenticated user, or regenerates (rotates) it if
+        one already exists. The previous subscribe URL immediately stops working.
+        Returns the full subscribe URL exactly once — it cannot be recovered afterwards.
+        Store it securely and add it to your calendar application.
+      security:
+        - KlabisAuth: [openid]
+      x-spring-provide-args:
+        - '@com.klabis.members.ActingUser com.klabis.common.users.UserId currentUserId'
+      responses:
+        '200':
+          description: New token generated; full subscribe URL returned once
+          content:
+            application/prs.hal-forms+json:
+              schema:
+                $ref: '#/components/schemas/EntityModelIcalTokenResponse'
+          x-hal-links:
+            self:
+              description: This token state
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+
+  # getMySchedule is documented here for completeness but NOT wired into openApiModule/codegen — see
+  # klabis-api-spec skill's "Registering a module for codegen" and IcalFeedController itself.
+  #
+  # Reasons this endpoint stays hand-written:
+  #   - it lives outside /api/, which every other spec-first path assumes
+  #   - it returns a raw RFC 5545 string (`text/calendar`), never wrapped in HAL — there is no
+  #     EntityModel/CollectionModel envelope to reference, so the "response must reference the
+  #     envelope" rule this skill otherwise enforces does not apply here
+  #   - the generator's schemaMappings mechanism exists to redirect envelope schemas onto existing
+  #     Java types; a bare `type: string` response body has no envelope to redirect, and mapping a
+  #     *response* schema (rather than a request/model schema) is not a capability
+  #     openApiModule's models/mappings options provide
+  #   - authentication is a raw `?token=` PAT, not the bearer-token security scheme every other
+  #     operation declares — modeling it as `security` here would misrepresent how the codegen
+  #     interface actually enforces it (it doesn't; IcalFeedController resolves the principal itself
+  #     from SecurityContextHolder)
+  # Verified HalResponseBodyAdvice.isHalMediaType(selectedContentType) returns false for
+  # "text/calendar", so the advice clears HalResponseContext and passes the ResponseEntity<String>
+  # body through untouched — consistent with this endpoint never populating HalResponseContext at all.
+  /ical/my-schedule.ics:
+    get:
+      operationId: getMySchedule
+      tags: [Calendar Feed]
+      summary: Personal schedule iCalendar feed
+      description: |
+        Returns an iCalendar (RFC 5545) feed for the authenticated user's personal schedule.
+        Includes events where the user is an active participant OR acts as coordinator.
+        Authenticate via the ?token= query parameter (Personal Access Token).
+      parameters:
+        - name: token
+          in: query
+          description: Personal Access Token for calendar authentication
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: iCalendar feed returned
+          content:
+            text/calendar:
+              schema:
+                type: string
+        '401':
+          description: Missing or invalid token
+          content:
+            application/problem+json:
+              schema:
+                $ref: './_shared/problem.yaml#/components/schemas/ProblemDetail'
+
+components:
+
+  parameters:
+    CalendarItemIdParam:
+      name: id
+      in: path
+      description: Calendar item UUID
+      required: true
+      schema:
+        type: string
+        format: uuid
+
+  responses:
+    BadRequest:
+      description: Bad request - invalid argument
+      content:
+        application/problem+json:
+          schema:
+            $ref: './_shared/problem.yaml#/components/schemas/ProblemDetail'
+    Unauthorized:
+      description: Unauthorized - authentication required
+      content:
+        application/problem+json:
+          schema:
+            $ref: './_shared/problem.yaml#/components/schemas/ProblemDetail'
+    Forbidden:
+      description: Forbidden - insufficient permissions
+      content:
+        application/problem+json:
+          schema:
+            $ref: './_shared/problem.yaml#/components/schemas/ProblemDetail'
+    NotFound:
+      description: Resource not found
+      content:
+        application/problem+json:
+          schema:
+            $ref: './_shared/problem.yaml#/components/schemas/ProblemDetail'
+    Conflict:
+      description: Conflict - concurrent update (optimistic locking failure)
+      content:
+        application/problem+json:
+          schema:
+            $ref: './_shared/problem.yaml#/components/schemas/ProblemDetail'
+    UnprocessableEntity:
+      description: Unprocessable entity - request violates a business rule
+      content:
+        application/problem+json:
+          schema:
+            $ref: './_shared/problem.yaml#/components/schemas/ProblemDetail'
+
+  schemas:
+
+    # Envelope schemas — never generated into Java; see klabis-api-spec skill:
+    # "Payload and envelope are separate schemas".
+    CollectionModelEntityModelCalendarItemDto:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            calendarItemDtoList:
+              type: array
+              items:
+                $ref: '#/components/schemas/EntityModelCalendarItemDto'
+        _links:
+          $ref: './_shared/hal.yaml#/components/schemas/Links'
+        _templates:
+          $ref: './_shared/hal.yaml#/components/schemas/HalFormsTemplates'
+
+    EntityModelCalendarItemDto:
+      allOf:
+        - $ref: '#/components/schemas/CalendarItemDto'
+        - type: object
+          properties:
+            _links:
+              $ref: './_shared/hal.yaml#/components/schemas/Links'
+            _templates:
+              $ref: './_shared/hal.yaml#/components/schemas/HalFormsTemplates'
+
+    CalendarItemDto:
+      type: object
+      description: A calendar item — either manually created or derived from an event's date.
+      properties:
+        id:
+          type: string
+          format: uuid
+          x-klabis-halforms-access: READ_ONLY
+        name:
+          type: string
+        description:
+          type: string
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        eventId:
+          type: string
+          format: uuid
+          description: Present only for event-linked items — the event this item is derived from.
+          x-klabis-halforms-access: READ_ONLY
+
+    CreateCalendarItemRequest:
+      type: object
+      description: Manual calendar item creation data
+      required: [name, startDate, endDate]
+      properties:
+        name:
+          type: string
+          maxLength: 200
+          # required + pattern reproduces @NotBlank(message = "Calendar item name is required") —
+          # see klabis-api-spec skill: OpenAPI has no keyword meaning "not blank", and
+          # CalendarItem.validateName() (Assert.hasText) already rejects whitespace-only names with
+          # the same 400 status, so this closes the same gap the domain guard would otherwise leave.
+          pattern: '^(?!\s*$).+'
+        description:
+          type: string
+          maxLength: 1000
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+
+    UpdateCalendarItemRequest:
+      type: object
+      description: Manual calendar item update data
+      required: [name, startDate, endDate]
+      properties:
+        name:
+          type: string
+          maxLength: 200
+          pattern: '^(?!\s*$).+'
+        description:
+          type: string
+          maxLength: 1000
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+
+    EntityModelIcalTokenResponse:
+      allOf:
+        - $ref: '#/components/schemas/IcalTokenResponse'
+        - type: object
+          properties:
+            _links:
+              $ref: './_shared/hal.yaml#/components/schemas/Links'
+            _templates:
+              $ref: './_shared/hal.yaml#/components/schemas/HalFormsTemplates'
+
+    IcalTokenResponse:
+      type: object
+      description: |
+        Current state of the caller's personal iCal feed token. `url` is masked except immediately
+        after generateToken, when it carries the full subscribe URL exactly once.
+      properties:
+        url:
+          type: string
+          nullable: true
+          x-klabis-halforms-access: READ_ONLY
+        lastSetAt:
+          type: string
+          format: date-time
+          nullable: true
+          x-klabis-halforms-access: READ_ONLY

--- a/docs/openapi/spec/event-types.yaml
+++ b/docs/openapi/spec/event-types.yaml
@@ -148,6 +148,8 @@ paths:
       responses:
         '204':
           description: Event type updated
+          content:
+            application/prs.hal-forms+json: {}
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -174,6 +176,8 @@ paths:
       responses:
         '204':
           description: Event type deleted
+          content:
+            application/prs.hal-forms+json: {}
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':

--- a/docs/openapi/spec/finance.yaml
+++ b/docs/openapi/spec/finance.yaml
@@ -1,0 +1,510 @@
+# Finance module — the API surface of MemberAccountController (finance module).
+#
+# These paths live under /api/members/{memberId}/account, which looks like a members path but is
+# served by the finance module's controller — see klabis-api-spec skill: "decide by which controller
+# serves it, not by the URL prefix."
+#
+# The three GET operations were guarded by an imperative checkAccountAccess() check: caller must be
+# the account owner OR hold FINANCE:MANAGE. That maps to x-klabis-authority + x-klabis-owner-visible
+# (OR semantics) on each GET operation. The three POST operations are FINANCE:MANAGE only — never
+# owner-accessible — so they carry x-klabis-authority alone.
+
+paths:
+
+  /api/members/{memberId}/account:
+    get:
+      operationId: getAccount
+      tags: [Finance]
+      summary: Get a member's finance account balance
+      description: Returns the current balance of a member's finance account.
+      security:
+        - KlabisAuth: [MEMBERS]
+      x-klabis-authority: FINANCE_MANAGE
+      x-klabis-owner-visible: memberId
+      x-spring-provide-args:
+        - '@com.klabis.members.ActingUser com.klabis.members.CurrentUserData currentUser'
+      parameters:
+        - $ref: '#/components/parameters/AccountMemberIdParam'
+      responses:
+        '200':
+          description: Account found
+          content:
+            application/prs.hal-forms+json:
+              schema:
+                $ref: '#/components/schemas/EntityModelMemberAccountResource'
+          x-hal-links:
+            self:
+              description: This account
+            transactions:
+              operation: listTransactions
+              description: Transaction history
+            accountOwner:
+              operation: getMember
+              description: The member this account belongs to
+          x-hal-templates:
+            deposit:
+              operation: deposit
+              description: Present only for callers with FINANCE:MANAGE
+            charge:
+              operation: charge
+              description: Present only for callers with FINANCE:MANAGE
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+
+  /api/members/{memberId}/account/transactions:
+    get:
+      operationId: listTransactions
+      tags: [Finance]
+      summary: List a member's account transactions
+      description: |
+        Paginated, filterable transaction history for a member's finance account. Supports
+        filtering by occurred-date range and transaction type.
+      security:
+        - KlabisAuth: [MEMBERS]
+      x-klabis-authority: FINANCE_MANAGE
+      x-klabis-owner-visible: memberId
+      x-spring-paginated: true
+      x-spring-provide-args:
+        - '@com.klabis.members.ActingUser com.klabis.members.CurrentUserData currentUser'
+      parameters:
+        - $ref: '#/components/parameters/AccountMemberIdParam'
+        - $ref: '#/components/parameters/PageParam'
+        - $ref: '#/components/parameters/SizeParam'
+        - $ref: '#/components/parameters/SortParam'
+        - name: occurredAtFrom
+          in: query
+          description: Only include transactions occurred on or after this date
+          required: false
+          schema:
+            type: string
+            format: date
+        - name: occurredAtTo
+          in: query
+          description: Only include transactions occurred on or before this date
+          required: false
+          schema:
+            type: string
+            format: date
+        - name: type
+          in: query
+          description: 'Transaction type filter: DEPOSIT, CHARGE, OTHER'
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Paginated transaction history
+          content:
+            application/prs.hal-forms+json:
+              schema:
+                $ref: '#/components/schemas/PagedModelEntityModelTransactionResource'
+          x-hal-links:
+            self:
+              description: This collection, with the current paging and filter parameters
+            first:
+              description: First page (present when the result is paged)
+            last:
+              description: Last page (present when the result is paged)
+            next:
+              description: Next page (present when one exists)
+            prev:
+              description: Previous page (present when one exists)
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+
+    post:
+      operationId: deposit
+      tags: [Finance]
+      summary: Record a deposit on a member's account
+      description: Records a deposit transaction, crediting the member's account balance.
+      security:
+        - KlabisAuth: [MEMBERS]
+      x-klabis-authority: FINANCE_MANAGE
+      x-spring-provide-args:
+        - '@com.klabis.members.ActingUser com.klabis.common.users.UserId currentUserId'
+      parameters:
+        - $ref: '#/components/parameters/AccountMemberIdParam'
+      requestBody:
+        required: true
+        x-codegen-request-body-name: request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DepositRequest'
+      responses:
+        '201':
+          description: Deposit recorded
+          headers:
+            Location:
+              description: URI of the created transaction
+              schema:
+                type: string
+                format: uri
+          content:
+            application/prs.hal-forms+json: {}
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+
+  /api/members/{memberId}/account/transactions/charge:
+    post:
+      operationId: charge
+      tags: [Finance]
+      summary: Record a charge on a member's account
+      description: Records a charge transaction, debiting the member's account balance.
+      security:
+        - KlabisAuth: [MEMBERS]
+      x-klabis-authority: FINANCE_MANAGE
+      x-spring-provide-args:
+        - '@com.klabis.members.ActingUser com.klabis.common.users.UserId currentUserId'
+      parameters:
+        - $ref: '#/components/parameters/AccountMemberIdParam'
+      requestBody:
+        required: true
+        x-codegen-request-body-name: request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChargeRequest'
+      responses:
+        '201':
+          description: Charge recorded
+          headers:
+            Location:
+              description: URI of the created transaction
+              schema:
+                type: string
+                format: uri
+          content:
+            application/prs.hal-forms+json: {}
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+
+  /api/members/{memberId}/account/transactions/{txId}:
+    get:
+      operationId: getTransaction
+      tags: [Finance]
+      summary: Get a single account transaction
+      description: Returns a single transaction on a member's finance account.
+      security:
+        - KlabisAuth: [MEMBERS]
+      x-klabis-authority: FINANCE_MANAGE
+      x-klabis-owner-visible: memberId
+      x-spring-provide-args:
+        - '@com.klabis.members.ActingUser com.klabis.members.CurrentUserData currentUser'
+      parameters:
+        - $ref: '#/components/parameters/AccountMemberIdParam'
+        - $ref: '#/components/parameters/TxIdParam'
+      responses:
+        '200':
+          description: Transaction found
+          content:
+            application/prs.hal-forms+json:
+              schema:
+                $ref: '#/components/schemas/EntityModelTransactionResource'
+          x-hal-links:
+            self:
+              description: This transaction
+            account:
+              description: The account this transaction belongs to
+            reversedBy:
+              description: The reversal transaction, when this transaction has been reversed
+            reverses:
+              description: The original transaction, when this transaction is itself a reversal
+            recordedBy:
+              operation: getMember
+              description: Member resource of the user who recorded this transaction
+          x-hal-templates:
+            reverse:
+              operation: reverse
+              description: |
+                Present only for callers with FINANCE:MANAGE, on a non-reversal transaction that
+                has not already been reversed.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+
+  /api/members/{memberId}/account/transactions/{txId}/reverse:
+    post:
+      operationId: reverse
+      tags: [Finance]
+      summary: Reverse an account transaction
+      description: |
+        Creates a reversal transaction offsetting the original. Fails with 409 when the transaction
+        has already been reversed.
+      security:
+        - KlabisAuth: [MEMBERS]
+      x-klabis-authority: FINANCE_MANAGE
+      x-spring-provide-args:
+        - '@com.klabis.members.ActingUser com.klabis.common.users.UserId currentUserId'
+      parameters:
+        - $ref: '#/components/parameters/AccountMemberIdParam'
+        - $ref: '#/components/parameters/TxIdParam'
+      requestBody:
+        required: true
+        x-codegen-request-body-name: request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReverseRequest'
+      responses:
+        '201':
+          description: Reversal recorded
+          headers:
+            Location:
+              description: URI of the created reversal transaction
+              schema:
+                type: string
+                format: uri
+          content:
+            application/prs.hal-forms+json: {}
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+
+components:
+
+  parameters:
+    AccountMemberIdParam:
+      name: memberId
+      in: path
+      description: Member UUID
+      required: true
+      schema:
+        type: string
+        format: uuid
+
+    TxIdParam:
+      name: txId
+      in: path
+      description: Transaction UUID
+      required: true
+      schema:
+        type: string
+        format: uuid
+
+  responses:
+    BadRequest:
+      description: Bad request - invalid argument
+      content:
+        application/problem+json:
+          schema:
+            $ref: './_shared/problem.yaml#/components/schemas/ProblemDetail'
+    Unauthorized:
+      description: Unauthorized - authentication required
+      content:
+        application/problem+json:
+          schema:
+            $ref: './_shared/problem.yaml#/components/schemas/ProblemDetail'
+    Forbidden:
+      description: Forbidden - insufficient permissions
+      content:
+        application/problem+json:
+          schema:
+            $ref: './_shared/problem.yaml#/components/schemas/ProblemDetail'
+    NotFound:
+      description: Resource not found
+      content:
+        application/problem+json:
+          schema:
+            $ref: './_shared/problem.yaml#/components/schemas/ProblemDetail'
+    Conflict:
+      description: Conflict - concurrent update (optimistic locking failure)
+      content:
+        application/problem+json:
+          schema:
+            $ref: './_shared/problem.yaml#/components/schemas/ProblemDetail'
+    UnprocessableEntity:
+      description: Unprocessable entity - request violates a business rule
+      content:
+        application/problem+json:
+          schema:
+            $ref: './_shared/problem.yaml#/components/schemas/ProblemDetail'
+
+  schemas:
+
+    # Envelope schemas — never generated into Java; see klabis-api-spec skill:
+    # "Payload and envelope are separate schemas".
+    EntityModelMemberAccountResource:
+      allOf:
+        - $ref: '#/components/schemas/MemberAccountResource'
+        - type: object
+          properties:
+            _links:
+              $ref: './_shared/hal.yaml#/components/schemas/Links'
+            _templates:
+              $ref: './_shared/hal.yaml#/components/schemas/HalFormsTemplates'
+
+    MemberAccountResource:
+      type: object
+      description: A member's finance account balance.
+      properties:
+        memberId:
+          type: string
+          format: uuid
+        balance:
+          type: number
+        currency:
+          type: string
+
+    # _embedded key follows TransactionResource's explicit @Relation(collectionRelation = "transactions"),
+    # not the class-name-derived default — see klabis-api-spec skill: "A payload schema's name is wire
+    # contract".
+    PagedModelEntityModelTransactionResource:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            transactions:
+              type: array
+              items:
+                $ref: '#/components/schemas/EntityModelTransactionResource'
+        _links:
+          $ref: './_shared/hal.yaml#/components/schemas/Links'
+        _templates:
+          $ref: './_shared/hal.yaml#/components/schemas/HalFormsTemplates'
+        page:
+          $ref: './_shared/hal.yaml#/components/schemas/PageMetadata'
+
+    EntityModelTransactionResource:
+      allOf:
+        - $ref: '#/components/schemas/TransactionResource'
+        - type: object
+          properties:
+            _links:
+              $ref: './_shared/hal.yaml#/components/schemas/Links'
+            _templates:
+              $ref: './_shared/hal.yaml#/components/schemas/HalFormsTemplates'
+
+    TransactionResource:
+      type: object
+      description: A single transaction on a member's finance account.
+      properties:
+        id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          description: 'DEPOSIT, CHARGE or OTHER'
+        amount:
+          type: number
+        currency:
+          type: string
+        note:
+          type: string
+        recordedAt:
+          type: string
+          format: date-time
+        occurredAt:
+          type: string
+          format: date
+        recordedBy:
+          type: string
+          format: uuid
+        reversesTransactionId:
+          type: string
+          format: uuid
+
+    DepositRequest:
+      type: object
+      description: Deposit creation data
+      required: [amount]
+      properties:
+        amount:
+          type: number
+          # exclusiveMinimum generates no Jakarta annotation with this generator config, so the
+          # spec cannot express "strictly positive" — MemberAccount.deposit() already asserts
+          # amount.isPositive() and rejects zero/negative with 400, just without a fieldErrors
+          # entry naming the field. See klabis-api-spec skill: validation gaps already covered by
+          # the domain guard degrade the error body only, not the enforcement.
+          minimum: 0
+        occurredAt:
+          type: string
+          format: date
+          description: Defaults to today when omitted.
+        note:
+          type: string
+
+    ChargeRequest:
+      type: object
+      description: Charge creation data
+      required: [amount]
+      properties:
+        amount:
+          type: number
+          minimum: 0
+        occurredAt:
+          type: string
+          format: date
+          description: Defaults to today when omitted.
+        note:
+          type: string
+
+    ReverseRequest:
+      type: object
+      description: Reversal data
+      properties:
+        note:
+          type: string
+        occurredAt:
+          type: string
+          format: date
+          description: Defaults to today when omitted.

--- a/docs/openapi/spec/klabis.yaml
+++ b/docs/openapi/spec/klabis.yaml
@@ -55,6 +55,15 @@ paths:
     $ref: './finance.yaml#/paths/~1api~1members~1{memberId}~1account~1transactions~1{txId}'
   /api/members/{memberId}/account/transactions/{txId}/reverse:
     $ref: './finance.yaml#/paths/~1api~1members~1{memberId}~1account~1transactions~1{txId}~1reverse'
+  /api/calendar-items:
+    $ref: './calendar.yaml#/paths/~1api~1calendar-items'
+  /api/calendar-items/{id}:
+    $ref: './calendar.yaml#/paths/~1api~1calendar-items~1{id}'
+  /api/me/ical-token:
+    $ref: './calendar.yaml#/paths/~1api~1me~1ical-token'
+  # Outside /api/ and not HAL: text/calendar feed authenticated by a ?token= query parameter.
+  /ical/my-schedule.ics:
+    $ref: './calendar.yaml#/paths/~1ical~1my-schedule.ics'
 
 components:
   securitySchemes:

--- a/docs/openapi/spec/klabis.yaml
+++ b/docs/openapi/spec/klabis.yaml
@@ -43,6 +43,18 @@ paths:
     $ref: './event-types.yaml#/paths/~1api~1event-types'
   /api/event-types/{id}:
     $ref: './event-types.yaml#/paths/~1api~1event-types~1{id}'
+  # /api/members/{memberId}/account* looks like a members path but is served by the finance
+  # module's controller — registered here, not in members.yaml. See finance.yaml header comment.
+  /api/members/{memberId}/account:
+    $ref: './finance.yaml#/paths/~1api~1members~1{memberId}~1account'
+  /api/members/{memberId}/account/transactions:
+    $ref: './finance.yaml#/paths/~1api~1members~1{memberId}~1account~1transactions'
+  /api/members/{memberId}/account/transactions/charge:
+    $ref: './finance.yaml#/paths/~1api~1members~1{memberId}~1account~1transactions~1charge'
+  /api/members/{memberId}/account/transactions/{txId}:
+    $ref: './finance.yaml#/paths/~1api~1members~1{memberId}~1account~1transactions~1{txId}'
+  /api/members/{memberId}/account/transactions/{txId}/reverse:
+    $ref: './finance.yaml#/paths/~1api~1members~1{memberId}~1account~1transactions~1{txId}~1reverse'
 
 components:
   securitySchemes:


### PR DESCRIPTION
Phase 5, first half: the two exploratory modules. 14 of the ~100 remaining
operations, picked because each carries a problem the phase 4 modules could
not exercise.

## What this proves

**finance** (6 ops) — a module can own paths under a URL prefix belonging to
another module. `/api/members/{memberId}/account*` is served by
`MemberAccountController`, and `klabis.yaml` registers those paths into
`finance.yaml` rather than `members.yaml`. This unblocks `membershipfees`,
which has the same shape.

Its authorization was **imperative**: a private `checkAccountAccess()`
enforcing "owner OR FINANCE:MANAGE", invisible to reflection and to the drift
check. That maps exactly onto `x-klabis-owner-visible` + `x-klabis-authority`,
so the helper and the controller's `@HasAuthority` annotations are gone and the
authority is stated once, in the spec.

**calendar** (8 ops) — the first non-HAL endpoint. `IcalFeedController` serves
`/ical/my-schedule.ics`: a raw RFC 5545 string, outside `/api/`, authenticated
by a `?token=` query parameter. `HalResponseBodyAdvice` passes it through
untouched, since `isHalMediaType()` matches only the two HAL types. It stays
hand-written and its tag is omitted from codegen; the spec still documents it.

No generator changes were needed for either module.

## A wire defect fixed along the way

A `201`/`204` response with no `content:` block generates `produces` containing
only `application/problem+json`, so a client sending
`Accept: application/prs.hal-forms+json` — as the frontend does on every
request — gets **406** instead of the success status.

Four operations had it: `updateCalendarItem`, `deleteCalendarItem`, and
`updateEventType`/`deleteEventType` from phase 4. It stayed hidden because the
MockMvc tests for those endpoints never set `.accept(...)`.

## Two silent generator behaviours

Both cost real time and are now in the skill, because the remaining modules
will hit them:

- **Multi-word `tags:` are dropped.** No warning, build succeeds, the `*Api`
  interface never appears. Six such tags remain in the unmigrated controllers,
  one with a trailing space.
- **A class-level `@RequestMapping` path doubles.** Generated methods carry the
  full absolute path, so `/api/foo` on the class yields `/api/foo/api/foo`.

## Verification

- Full backend suite: **3203 tests, 0 failures, 15 skipped** — baseline
  unchanged. `EventTypeControllerTest` passes unmodified after the 204 change.
- Bundle valid: 26 operations, 58 schemas.
- `docs/openapi/klabis-full.json` unchanged (`ca397906af263418c8f15db8859bd6de`)
  — this migration alters no published API document.
- Existing controller tests pass **unmodified**, which is the evidence that the
  wire format did not change.

One test did need changing, and it is worth reading:
`AccountRootLinkProcessorTest` only ever passed because
`HalFormsSupport.INSTANCE` is null without a Spring context, which
short-circuits the authorization check entirely — so it never tested
authorization at all. Once `getAccount` carried discoverable annotations, the
real check ran and denied. It now wires a genuine `OwnershipResolver` and
grants the link via ownership with no authorities, which is a stronger
assertion than the original. Production behaviour is unaffected:
`MemberAccountControllerTest` covers owner 200 / non-owner 403 /
FINANCE:MANAGE 200 with real authentication, unmodified.

## Remaining after this

86 operations in four modules: events 22, membershipfees 25, groups 30,
common+oris 9. Those are mechanical by comparison and land in a second PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)