### PR TITLE
docs(openapi): move suspendMember 409 contract into the spec

### DIFF
--- a/.claude/skills/backend-patterns/SKILL.md
+++ b/.claude/skills/backend-patterns/SKILL.md
@@ -342,16 +342,15 @@ Use `klabisLinkTo()` (returns `Optional<WebMvcLinkBuilder>`) and `klabisAfford()
 
 #### Which annotations belong on the override
 
-The interface is the declaration site for everything the framework reads — but springdoc is the
-exception, because it scans the concrete class. "Remove whatever the interface already has" is the
-intuitive generalization and it is wrong.
+The interface is the declaration site for everything the framework reads. The override carries the
+method body and nothing else.
 
 | Annotation | Where it belongs | Why |
 |---|---|---|
 | `@RequestBody`, `@RequestParam`, `@PathVariable` | interface only | Spring MVC and `HalFormsSupport` both read them from there |
 | `@NotNull`, `@Size`, `@Pattern`, … | interface only | see the HV000151 note below |
 | `@Valid` | either | a cascade marker, not a constraint — repeating it is legal |
-| `@Parameter`, `@Operation`, `@ApiResponse` | **controller** | springdoc scans the implementation; stripping these empties out `klabis-full.json` |
+| `@Parameter`, `@Operation`, `@ApiResponse` | interface only, and generated | the generator emits them from the spec (`documentationProvider=springdoc`); a hand-written copy on the controller only drifts |
 
 **Bean Validation is all-or-nothing.** Hibernate Validator rejects an override that *redefines* the
 parameter constraint configuration of the method it overrides (`ConstraintDeclarationException:

--- a/.claude/skills/klabis-api-spec/SKILL.md
+++ b/.claude/skills/klabis-api-spec/SKILL.md
@@ -35,31 +35,36 @@ is a single source of truth end to end.
   the `*Dto` suffix.
 - Changing the spec requires regenerating **both** the bundle (`./gradlew openapiBundle`) and the
   frontend types (`npm run openapi` from `frontend/`).
-- **Controllers keep their springdoc annotations** — see below.
+- **Never put `@Operation` / `@ApiResponse` / `@Parameter` on a controller** — see below.
 
-#### Why `@Operation` / `@ApiResponse` / `@Parameter` stay on the controller
+#### Why the controllers carry no springdoc annotations
 
-They duplicate `summary`, `description` and response descriptions that the spec already states, so
-they look like leftovers. They are not: springdoc reads annotations off the **concrete class**, and
-Java does not inherit method annotations from an interface. Deleting them compiles fine and silently
-guts `klabis-full.json` — `summary` and `description` become `null`, parameter descriptions vanish,
-and response descriptions degrade to a bare `"OK"`. Only `tags` and `operationId` survive, because
-those are derived from the class and method names.
+`documentationProvider = "springdoc"` makes the generator emit them onto the `*Api` interface,
+straight from the spec. Springdoc reads annotations off the concrete class and Java does not inherit
+method annotations from an interface — but the controller `@Override`s a method whose *declaration*
+carries them, and springdoc resolves that. So `/v3/api-docs` is spec-derived too, and hand-written
+duplicates are pure drift surface.
 
-(This is the same inheritance gap `@HasAuthority` has. There we bridged it with
-`MethodSecurityAnnotations`; springdoc offers no equivalent hook and is not worth patching for a
-component being removed.)
+The generated set is strictly richer than what the controllers used to hold: it also carries
+`security`, `tags`, every error response with its description and `@Content` schema, and
+`@Parameter(hidden = true)` on the `x-spring-provide-args` arguments. Measured over the whole app
+when the 26 controllers were stripped: operations 117 → 117 (none lost), summaries 82 → 117,
+descriptions 51 → 111, parameter descriptions 95 → 133.
 
-The generator's own `documentationProvider = "springdoc"` would emit these annotations onto the
-interface — richer than the hand-written ones, since it also carries the error-response descriptions.
-It does not work here: it renders `@Schema(implementation = …)` from `schemaMappings`, and our
-envelope mappings target *generic* types, producing `java.util.Collection<…EventTypeDto>.class` —
-not valid Java. Both migrated modules hit it (`Collection<T>` and `Page<T>` alike), so it is a direct
-conflict with how envelopes are mapped, not an edge case.
+**The catch is generic `schemaMappings`.** `documentationProvider` renders each response's baseType
+into `@Schema(implementation = <baseType>.class)`, and the envelope mappings target *generic* types,
+producing `java.util.Collection<…EventTypeDto>.class` — not legal Java (JLS 15.8.2: a class literal
+takes a raw type). 27 occurrences across 5 modules. The generator has no hook for it: stock
+`api.mustache` emits `{{{baseType}}}` verbatim, Mustache cannot transform a string, and a lambda
+would mean subclassing `SpringCodegen`. `openApiModule` therefore erases the type arguments in a
+`doLast` over the generated `*Api.java`. That erasure is declared via `inputs.property` — a `doLast`
+body is not part of a task's cache fingerprint, so without it a cached output could be restored
+having been patched by an older version of the rule.
 
-So: leave them for now. They no longer feed the published document — `openapiBundle` does — but
-stripping them is a separate mechanical pass, and until it happens they are what `/v3/api-docs`
-serves to anyone introspecting the running app.
+The exceptions are the 7 files with no generated counterpart, which legitimately keep their
+annotations: `OpenApiConfig` (global info + security scheme), `MvcExceptionHandler` and
+`GroupsExceptionHandler`, the hand-written `MemberOptionResponse`/`MemberSummaryResponse`, and
+`@Hidden` on `ActingUser`/`ActingMember`.
 
 ## Layout
 
@@ -513,8 +518,8 @@ Two guards, both worth knowing because each fails at a different moment:
 
 - **`halTypes.ts` indexes into `klabisApi.d.ts`** by schema name
   (`components['schemas']['EntityModelEventTypeDto']`). A name that does not exist there is a `tsc`
-  error — loud, immediate. This one is an artifact of `klabisApi.d.ts` coming from springdoc (see
-  the exception at the top) and disappears once the bundler owns `klabis-full.json`.
+  error — loud, immediate. Since the bundler owns `klabis-full.json`, that name comes from the spec,
+  so the fix is to correct the schema name there and regenerate — never to edit `klabisApi.d.ts`.
 - **The `_embedded` key is not checked by anything.** Getting it wrong in the envelope produces
   frontend types naming a property no response ever contains: `undefined` at runtime, an empty list
   in the UI, no error anywhere.
@@ -782,9 +787,8 @@ returns `true` unconditionally makes the test assert nothing.
   real `OwnershipResolver` instead
 - Writing `@HasAuthority` on a controller method — the authority belongs in `x-klabis-authority`,
   stated once
-- Stripping `@Operation` / `@ApiResponse` / `@Parameter` off a controller because "the spec already
-  says that" — springdoc cannot see them through the interface, and the published document loses its
-  summaries and descriptions
+- Writing `@Operation` / `@ApiResponse` / `@Parameter` on a controller — the generator emits them
+  onto the `*Api` interface from the spec, and a hand-written copy only drifts from it
 - Hand-writing `x-operation-extra-annotation` to inject `@HasAuthority` — that is the bundler's
   output, not the interface you author against
 - Inventing a new `x-klabis-*` extension: each must map to an annotation the generator can reliably

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -399,7 +399,12 @@ openApiModule(
         "TrainerLicenseDto_level" to "com.klabis.members.domain.TrainerLevel",
         "RefereeLicenseDto_level" to "com.klabis.members.domain.RefereeLevel",
         "EntityModelMemberDetailsResponse" to "com.klabis.members.infrastructure.restapi.MemberDetailsResponse",
-        "PagedModelEntityModelMemberSummaryResponse" to "org.springframework.data.domain.Page<com.klabis.members.infrastructure.restapi.MemberSummaryResponse>"
+        "PagedModelEntityModelMemberSummaryResponse" to "org.springframework.data.domain.Page<com.klabis.members.infrastructure.restapi.MemberSummaryResponse>",
+        // suspendMember's 409 body. The real types are package-private nested records of
+        // MembersExceptionHandler, so there is nothing to map onto; Object keeps the generator
+        // from importing a model it was never asked to generate. Response-only — the interface
+        // declares ResponseEntity<Void>, so this mapping never reaches a method signature.
+        "SuspensionBlockedWarning" to "java.lang.Object"
     ),
     // The generic Page<T> mapping above carries type arguments that the import statement must not repeat.
     extraImportMappings = mapOf(

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -342,7 +342,7 @@ fun openApiModule(
                 "skipDefaultInterface" to "true",
                 "useSpringBoot3" to "true",
                 "useJakartaEe" to "true",
-                "documentationProvider" to "none",
+                "documentationProvider" to "springdoc",
                 // Emits JsonNullable<T> for a nullable property, giving PATCH bodies their
                 // absent/null/value tri-state. Requires the OpenAPI 3.1 spelling
                 // `type: [x, "null"]` — the 3.0 `nullable: true` keyword leaves isNullable false.
@@ -364,6 +364,45 @@ fun openApiModule(
         val commonMappings = mapOf("ProblemDetail" to "org.springframework.http.ProblemDetail")
         schemaMappings.set(mappings + commonMappings)
         importMappings.set(mappings + commonMappings + extraImportMappings + mapOf("Instant" to "java.time.Instant"))
+
+        // `documentationProvider=springdoc` renders each response's baseType into
+        // `@Schema(implementation = <baseType>.class)`. For the envelope schemaMappings above that
+        // baseType carries type arguments — `Page<MemberSummaryResponse>.class` — which is not
+        // legal Java (JLS 15.8.2: a class literal takes a raw type). The generator has no hook for
+        // this: the stock api.mustache emits {{{baseType}}} verbatim, Mustache cannot transform a
+        // string, and registering a lambda would mean subclassing SpringCodegen.
+        //
+        // Drop the response's whole `content = {...}` block, not just the offending `@Schema`.
+        // Springdoc derives the schema from the method's *return type* — which still carries the
+        // type argument — but only for an @ApiResponse that declares no content at all. Anything
+        // left behind wins over that fallback and makes the document worse than before: a raw
+        // `Page.class` flattens to a bare `Page` (and `Collection.class` to `"type": "string"`),
+        // while a bare `@Content(mediaType = ...)` yields an empty `{}`. Measured over all three
+        // variants; only removing the block keeps `PageMemberSummaryResponse` and the array shapes.
+        //
+        // `java.lang.Object` — what a schemaMapping falls back to when no Java type names the
+        // response body — gets the same treatment for the same reason: springdoc renders it as
+        // `"type": "string"`, which is worse than saying nothing.
+        //
+        // Anchored on `content = {` … `}` containing an unusable class literal. `[^{}]*` cannot
+        // span the block's own braces, so the match stops at the right `}`.
+        val unusableResponseContent =
+            Regex(""",\s*content = \{[^{}]*implementation = (?:[\w.]+<|java\.lang\.Object\b)[^{}]*\}""")
+
+        // GenerateTask is @CacheableTask, and Gradle fingerprints only declared inputs — never the
+        // body of a doLast closure. Without this the task could be restored from the build cache
+        // with the output of an *older* version of the patch below, and the edit would never run.
+        inputs.property("unusableResponseContent", unusableResponseContent.pattern)
+
+        doLast {
+            outputDir.get().asFile.walkTopDown()
+                .filter { it.isFile && it.name.endsWith("Api.java") }
+                .forEach { file ->
+                    val original = file.readText()
+                    val patched = original.replace(unusableResponseContent, "")
+                    if (patched != original) file.writeText(patched)
+                }
+        }
     }
 
     // Part of the main sourceSet (not a separate one) so Lombok -> MapStruct -> RecordBuilder
@@ -400,10 +439,14 @@ openApiModule(
         "RefereeLicenseDto_level" to "com.klabis.members.domain.RefereeLevel",
         "EntityModelMemberDetailsResponse" to "com.klabis.members.infrastructure.restapi.MemberDetailsResponse",
         "PagedModelEntityModelMemberSummaryResponse" to "org.springframework.data.domain.Page<com.klabis.members.infrastructure.restapi.MemberSummaryResponse>",
-        // suspendMember's 409 body. The real types are package-private nested records of
-        // MembersExceptionHandler, so there is nothing to map onto; Object keeps the generator
-        // from importing a model it was never asked to generate. Response-only — the interface
-        // declares ResponseEntity<Void>, so this mapping never reaches a method signature.
+        // suspendMember's 409 body: a oneOf of two records that MembersExceptionHandler declares
+        // and the interface never names (it returns ResponseEntity<Void>), so no Java type stands
+        // for the union. Object is the honest answer, and it also stops the generator importing a
+        // model it was not asked to generate. Generating the union instead does not work — the
+        // generator flattens a discriminator-less oneOf into one record holding every branch's
+        // fields, each @NotNull, which nothing can satisfy. The published contract in
+        // klabis-full.json still carries the full oneOf; only /v3/api-docs goes without, since the
+        // doLast below drops the `"type": "string"` springdoc would otherwise infer from Object.
         "SuspensionBlockedWarning" to "java.lang.Object"
     ),
     // The generic Page<T> mapping above carries type arguments that the import statement must not repeat.

--- a/backend/src/main/java/com/klabis/calendar/infrastructure/restapi/CalendarController.java
+++ b/backend/src/main/java/com/klabis/calendar/infrastructure/restapi/CalendarController.java
@@ -8,17 +8,11 @@ import com.klabis.common.mvc.MvcComponent;
 import com.klabis.common.ui.HalResponseContext;
 import com.klabis.common.ui.ModelWithDomainPostprocessor;
 import com.klabis.common.ui.RootModel;
-import com.klabis.common.users.Authority;
 import com.klabis.events.EventId;
 import com.klabis.events.infrastructure.restapi.EventsApi;
 import com.klabis.members.ActingUser;
 import com.klabis.members.CurrentUserData;
 import com.klabis.members.MemberId;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springframework.data.domain.Sort;
 import org.springframework.hateoas.CollectionModel;
@@ -43,10 +37,8 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @RestController
 @RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)
-@Tag(name = "Calendar", description = "Calendar item management API")
 @PrimaryAdapter
 @ExposesResourceFor(CalendarItem.class)
-@SecurityRequirement(name = "KlabisAuth", scopes = {Authority.CALENDAR_SCOPE})
 class CalendarController implements CalendarApi {
 
     private final CalendarManagementPort calendarManagementService;
@@ -55,28 +47,11 @@ class CalendarController implements CalendarApi {
         this.calendarManagementService = calendarManagementService;
     }
 
-    @Operation(
-            summary = "List calendar items with date range filtering",
-            description = """
-                    Retrieves a list of calendar items filtered by date range.
-                    If dates not provided, defaults to current month.
-                    Maximum date range is 1 year (366 days).
-                    Default sort: startDate,asc. Allowed fields: id, name, startDate, endDate.
-                    When mySchedule=true, returns only EVENT_DATE items linked to events where the current
-                    user is an active participant or event coordinator.
-                    """
-    )
-    @ApiResponse(responseCode = "200", description = "List of calendar items retrieved successfully")
-    @ApiResponse(responseCode = "400", description = "Date range exceeds 366 days or invalid sort field")
     @Override
     public ResponseEntity<Collection<CalendarItemDto>> listCalendarItems(
-            @Parameter(description = "Start date for filtering (ISO DATE format, defaults to first day of current month)")
             LocalDate startDate,
-            @Parameter(description = "End date for filtering (ISO DATE format, defaults to last day of current month)")
             LocalDate endDate,
-            @Parameter(description = "Sorting parameters (default: startDate,asc)")
             String sort,
-            @Parameter(description = "When true, restricts results to EVENT_DATE items for events where the current user is a participant or coordinator")
             Boolean mySchedule,
             @ActingUser CurrentUserData currentUser) {
 
@@ -124,15 +99,9 @@ class CalendarController implements CalendarApi {
         return Sort.by(direction, field);
     }
 
-    @Operation(
-            summary = "Get calendar item by ID",
-            description = "Retrieves detailed calendar item information by ID. " +
-                          "Returns HATEOAS links based on whether the item is manually created or event-linked."
-    )
-    @ApiResponse(responseCode = "200", description = "Calendar item found")
     @Override
     public ResponseEntity<CalendarItemDto> getCalendarItem(
-            @Parameter(description = "Calendar item UUID") UUID id) {
+            UUID id) {
 
         CalendarItem calendarItem = calendarManagementService.getCalendarItem(new CalendarItemId(id));
 
@@ -140,16 +109,9 @@ class CalendarController implements CalendarApi {
         return ResponseEntity.ok(toDto(calendarItem));
     }
 
-    @Operation(
-            summary = "Create a new manual calendar item",
-            description = "Creates a new manual calendar item (not linked to an event). " +
-                          "Manual items can be updated and deleted. " +
-                          "Returns Location header pointing to the created resource."
-    )
-    @ApiResponse(responseCode = "201", description = "Calendar item successfully created")
     @Override
     public ResponseEntity<Void> createCalendarItem(
-            @Parameter(description = "Calendar item creation data") CreateCalendarItemRequest request) {
+            CreateCalendarItemRequest request) {
 
         CalendarItem created = calendarManagementService.createCalendarItem(toCommand(request));
 
@@ -160,19 +122,10 @@ class CalendarController implements CalendarApi {
                 .build();
     }
 
-    @Operation(
-            summary = "Update a manual calendar item",
-            description = """
-                    Updates calendar item information. Only allowed for manual items (not event-linked).
-                    Event-linked items are read-only and managed automatically.
-                    """
-    )
-    @ApiResponse(responseCode = "204", description = "Calendar item successfully updated")
-    @ApiResponse(responseCode = "400", description = "Cannot update event-linked calendar item")
     @Override
     public ResponseEntity<Void> updateCalendarItem(
-            @Parameter(description = "Calendar item UUID") UUID id,
-            @Parameter(description = "Calendar item update data") UpdateCalendarItemRequest request) {
+            UUID id,
+            UpdateCalendarItemRequest request) {
 
         calendarManagementService.updateCalendarItem(new CalendarItemId(id), toCommand(request));
         return ResponseEntity.noContent().build();
@@ -192,17 +145,9 @@ class CalendarController implements CalendarApi {
         return description != null && description.isBlank() ? null : description;
     }
 
-    @Operation(
-            summary = "Delete a manual calendar item",
-            description = "Deletes a manual calendar item. " +
-                          "Only allowed for manual items (not event-linked). " +
-                          "Event-linked items are read-only and managed automatically."
-    )
-    @ApiResponse(responseCode = "204", description = "Calendar item successfully deleted")
-    @ApiResponse(responseCode = "400", description = "Cannot delete event-linked calendar item")
     @Override
     public ResponseEntity<Void> deleteCalendarItem(
-            @Parameter(description = "Calendar item UUID") UUID id) {
+            UUID id) {
 
         calendarManagementService.deleteCalendarItem(new CalendarItemId(id));
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/com/klabis/calendar/infrastructure/restapi/IcalFeedController.java
+++ b/backend/src/main/java/com/klabis/calendar/infrastructure/restapi/IcalFeedController.java
@@ -5,10 +5,6 @@ import com.klabis.calendar.application.IcalFeedPort.EventScheduleEntry;
 import com.klabis.calendar.infrastructure.ical.ICalendarRenderer;
 import com.klabis.common.users.UserId;
 import com.klabis.members.MemberId;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.CacheControl;
@@ -28,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 
 @PrimaryAdapter
 @RestController
-@Tag(name = "Calendar Feed", description = "iCalendar subscribe feed for personal schedule")
 class IcalFeedController implements IcalFeedApi {
 
     private static final MediaType TEXT_CALENDAR = new MediaType("text", "calendar", StandardCharsets.UTF_8);
@@ -47,18 +42,7 @@ class IcalFeedController implements IcalFeedApi {
     }
 
     @Override
-    @Operation(
-            summary = "Personal schedule iCalendar feed",
-            description = """
-                    Returns an iCalendar (RFC 5545) feed for the authenticated user's personal schedule.
-                    Includes events where the user is an active participant OR acts as coordinator.
-                    Authenticate via the ?token= query parameter (Personal Access Token).
-                    """
-    )
-    @ApiResponse(responseCode = "200", description = "iCalendar feed returned")
-    @ApiResponse(responseCode = "401", description = "Missing or invalid token")
     public ResponseEntity<String> getMySchedule(
-            @Parameter(description = "Personal Access Token for calendar authentication", required = true)
             @RequestParam String token) {
 
         MemberId memberId = resolveAuthenticatedMemberId();

--- a/backend/src/main/java/com/klabis/calendar/infrastructure/restapi/IcalTokenController.java
+++ b/backend/src/main/java/com/klabis/calendar/infrastructure/restapi/IcalTokenController.java
@@ -5,10 +5,6 @@ import com.klabis.common.mvc.MvcComponent;
 import com.klabis.common.ui.HalResponseContext;
 import com.klabis.common.users.UserId;
 import com.klabis.members.ActingUser;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.hateoas.EntityModel;
@@ -27,8 +23,6 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @PrimaryAdapter
 @RestController
 @RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)
-@Tag(name = "Calendar Feed Token", description = "iCalendar feed token management for the current user")
-@SecurityRequirement(name = "KlabisAuth", scopes = {"openid"})
 class IcalTokenController implements IcalTokenApi {
 
     private final IcalTokenPort icalTokenPort;
@@ -41,17 +35,6 @@ class IcalTokenController implements IcalTokenApi {
         this.baseUrl = baseUrl;
     }
 
-    @Operation(
-            summary = "Get iCal feed token state",
-            description = """
-                    Returns the current iCal feed token state for the authenticated user.
-                    If a token exists, returns the masked subscribe URL and the timestamp when the token was last set.
-                    The URL is masked — the full raw token is never stored and can only be revealed at generation time.
-                    Use the 'regenerate' affordance (POST) to create or rotate the token and receive the full URL once.
-                    If no token exists, returns url=null.
-                    """
-    )
-    @ApiResponse(responseCode = "200", description = "Token state returned")
     @Override
     public ResponseEntity<IcalTokenResponse> getTokenState(@ActingUser UserId currentUserId) {
         IcalTokenResponse response = icalTokenPort.getTokenState(currentUserId)
@@ -61,16 +44,6 @@ class IcalTokenController implements IcalTokenApi {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(
-            summary = "Generate or regenerate iCal feed token",
-            description = """
-                    Generates a new iCal feed token for the authenticated user, or regenerates (rotates) it if one
-                    already exists. The previous subscribe URL immediately stops working.
-                    Returns the full subscribe URL exactly once — it cannot be recovered afterwards.
-                    Store it securely and add it to your calendar application.
-                    """
-    )
-    @ApiResponse(responseCode = "200", description = "New token generated; full subscribe URL returned once")
     @Override
     public ResponseEntity<IcalTokenResponse> generateToken(@ActingUser UserId currentUserId) {
         IcalTokenPort.GenerateResult result = icalTokenPort.generateOrRotate(currentUserId);

--- a/backend/src/main/java/com/klabis/common/ui/DashboardController.java
+++ b/backend/src/main/java/com/klabis/common/ui/DashboardController.java
@@ -2,8 +2,6 @@ package com.klabis.common.ui;
 
 import com.klabis.common.mvc.MvcComponent;
 import com.klabis.common.users.infrastructure.restapi.DashboardApi;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
@@ -16,8 +14,6 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @RestController
 @RequestMapping(produces = {MediaTypes.HAL_JSON_VALUE, MediaTypes.HAL_FORMS_JSON_VALUE})
-@Tag(name = "Dashboard", description = "Dashboard widget link index")
-@SecurityRequirement(name = "KlabisAuth", scopes = {"openid"})
 class DashboardController implements DashboardApi {
 
     @Override

--- a/backend/src/main/java/com/klabis/common/ui/RootController.java
+++ b/backend/src/main/java/com/klabis/common/ui/RootController.java
@@ -2,8 +2,6 @@ package com.klabis.common.ui;
 
 import com.klabis.common.mvc.MvcComponent;
 import com.klabis.common.users.infrastructure.restapi.RootApi;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.MediaTypes;
@@ -19,8 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping(produces = {MediaTypes.HAL_JSON_VALUE, MediaTypes.HAL_FORMS_JSON_VALUE})
-@Tag(name = "Root", description = "API root navigation")
-@SecurityRequirement(name = "KlabisAuth", scopes = {"openid"})
 class RootController implements RootApi {
 
     // Links are added in postprocessors from respective modules, bound on EntityModel<RootModel>.

--- a/backend/src/main/java/com/klabis/common/users/infrastructure/restapi/PasswordChangeController.java
+++ b/backend/src/main/java/com/klabis/common/users/infrastructure/restapi/PasswordChangeController.java
@@ -2,10 +2,6 @@ package com.klabis.common.users.infrastructure.restapi;
 
 import com.klabis.common.security.KlabisJwtAuthenticationToken;
 import com.klabis.common.users.application.PasswordChangePort;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -15,8 +11,6 @@ import org.springframework.web.bind.annotation.RestController;
 @PrimaryAdapter
 @RestController
 @RequestMapping
-@Tag(name = "MyProfile", description = "Current authenticated user operations")
-@SecurityRequirement(name = "KlabisAuth", scopes = {"openid"})
 class PasswordChangeController implements MyProfileApi {
 
     private final PasswordChangePort passwordChangePort;
@@ -26,12 +20,6 @@ class PasswordChangeController implements MyProfileApi {
     }
 
     @Override
-    @Operation(
-            summary = "Change password",
-            description = "Changes the current user's password. Requires the correct current password."
-    )
-    @ApiResponse(responseCode = "204", description = "Password changed successfully")
-    @ApiResponse(responseCode = "400", description = "Incorrect current password or new password fails complexity rules")
     public ResponseEntity<Void> changePassword(
             ChangePasswordRequest request,
             Authentication authentication) {

--- a/backend/src/main/java/com/klabis/common/users/infrastructure/restapi/PasswordSetupController.java
+++ b/backend/src/main/java/com/klabis/common/users/infrastructure/restapi/PasswordSetupController.java
@@ -5,19 +5,11 @@ import com.klabis.common.users.domain.PasswordSetupToken;
 import com.klabis.common.users.domain.TokenAlreadyUsedException;
 import com.klabis.common.users.domain.TokenExpiredException;
 import com.klabis.common.users.domain.User;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -34,7 +26,6 @@ import org.springframework.web.bind.annotation.RestController;
  * </ul>
  */
 @RestController
-@Tag(name = "PasswordSetup", description = "Password setup and account activation API")
 @PrimaryAdapter
 public class PasswordSetupController implements PasswordSetupApi {
 
@@ -56,11 +47,6 @@ public class PasswordSetupController implements PasswordSetupApi {
      * @return validation response with masked email and expiration time
      */
     @Override
-    @Operation(summary = "Validate password setup token", description = "Validates a token before showing the password setup form")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Token is valid", content = @Content(schema = @Schema(implementation = ValidateTokenResponse.class))),
-    })
-    @Parameter(name = "token", description = "The plain text token from the email link", required = true, example = "abc123def456")
     public ResponseEntity<ValidateTokenResponse> validatePasswordSetupToken(String token) {
         PasswordSetupToken setupToken = passwordSetupService.validateToken(token);
         return ResponseEntity.ok(ValidateTokenResponseBuilder.builder()
@@ -80,8 +66,6 @@ public class PasswordSetupController implements PasswordSetupApi {
      * @return success response with registration number
      */
     @Override
-    @Operation(summary = "Complete password setup", description = "Sets the user's password and activates the account")
-    @ApiResponse(responseCode = "200", description = "Password set successfully")
     public ResponseEntity<PasswordSetupResponse> completePasswordSetup(
             SetPasswordRequest request,
             HttpServletRequest httpRequest) {
@@ -121,8 +105,6 @@ public class PasswordSetupController implements PasswordSetupApi {
      * @return success message (generic response for security)
      */
     @Override
-    @Operation(summary = "Request new password setup token", description = "Requests a new token if the previous one expired")
-    @ApiResponse(responseCode = "200", description = "Request processed successfully")
     public ResponseEntity<TokenRequestResponse> requestNewPasswordSetupToken(TokenRequestRequest request) {
         passwordSetupService.requestNewToken(request.registrationNumber(), request.email());
         return ResponseEntity.ok(new TokenRequestResponse(
@@ -151,21 +133,11 @@ public class PasswordSetupController implements PasswordSetupApi {
         return ip;
     }
 
-    @ApiResponse(
-            responseCode = "410",
-            description = "Token expired or already used",
-            content = @Content(mediaType = "application/problem+json", schema = @Schema(implementation = ProblemDetail.class))
-    )
     @ExceptionHandler(TokenExpiredException.class)
     public ErrorResponse handleTokenExpired(TokenExpiredException e) {
         return ErrorResponse.create(e, HttpStatus.GONE, "Token has expired. Please request a new one.");
     }
 
-    @ApiResponse(
-            responseCode = "410",
-            description = "Token expired or already used",
-            content = @Content(mediaType = "application/problem+json", schema = @Schema(implementation = ProblemDetail.class))
-    )
     @ExceptionHandler(TokenAlreadyUsedException.class)
     public ErrorResponse handleTokenAlreadyUsed(TokenAlreadyUsedException e) {
         return ErrorResponse.create(e, HttpStatus.GONE, "Token has already been used. Please request a new one.");

--- a/backend/src/main/java/com/klabis/common/users/infrastructure/restapi/PermissionController.java
+++ b/backend/src/main/java/com/klabis/common/users/infrastructure/restapi/PermissionController.java
@@ -10,8 +10,6 @@ import com.klabis.common.users.domain.AuthorizationPolicy;
 import com.klabis.common.users.domain.CannotRemoveLastPermissionManagerException;
 import com.klabis.common.users.domain.UserNotFoundException;
 import com.klabis.common.users.domain.UserPermissions;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.MediaTypes;
@@ -43,9 +41,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
  */
 @RestController
 @RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)
-@Tag(name = "Permissions", description = "User permission management")
 @PrimaryAdapter
-@SecurityRequirement(name = "KlabisAuth", scopes = {Authority.MEMBERS_SCOPE})
 @ExposesResourceFor(UserPermissions.class)
 public class PermissionController implements PermissionsApi {
 

--- a/backend/src/main/java/com/klabis/events/infrastructure/restapi/CategoryPresetController.java
+++ b/backend/src/main/java/com/klabis/events/infrastructure/restapi/CategoryPresetController.java
@@ -3,15 +3,9 @@ package com.klabis.events.infrastructure.restapi;
 import com.klabis.common.mvc.MvcComponent;
 import com.klabis.common.ui.HalResponseContext;
 import com.klabis.common.ui.ModelWithDomainPostprocessor;
-import com.klabis.common.users.Authority;
 import com.klabis.events.CategoryPresetId;
 import com.klabis.events.application.CategoryPresetManagementPort;
 import com.klabis.events.domain.CategoryPreset;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
@@ -36,10 +30,8 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @RestController
 @RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)
-@Tag(name = "CategoryPresets", description = "Category preset management API")
 @PrimaryAdapter
 @ExposesResourceFor(CategoryPreset.class)
-@SecurityRequirement(name = "KlabisAuth", scopes = {Authority.EVENTS_SCOPE})
 class CategoryPresetController implements CategoryPresetsApi {
 
     private final CategoryPresetManagementPort categoryPresetManagementService;
@@ -48,11 +40,6 @@ class CategoryPresetController implements CategoryPresetsApi {
         this.categoryPresetManagementService = categoryPresetManagementService;
     }
 
-    @Operation(
-            summary = "List all category presets",
-            description = "Returns all category presets. Requires EVENTS:MANAGE authority."
-    )
-    @ApiResponse(responseCode = "200", description = "List of category presets")
     @Override
     public ResponseEntity<Collection<CategoryPresetDto>> listPresets() {
         List<CategoryPreset> presets = categoryPresetManagementService.listAll();
@@ -63,14 +50,9 @@ class CategoryPresetController implements CategoryPresetsApi {
         return ResponseEntity.ok(payload);
     }
 
-    @Operation(
-            summary = "Get category preset by ID",
-            description = "Returns a single category preset. Requires EVENTS:MANAGE authority."
-    )
-    @ApiResponse(responseCode = "200", description = "Category preset found")
     @Override
     public ResponseEntity<CategoryPresetDto> getPreset(
-            @Parameter(description = "Preset UUID") @PathVariable UUID id) {
+            @PathVariable UUID id) {
 
         CategoryPreset preset = categoryPresetManagementService.getPreset(new CategoryPresetId(id));
 
@@ -78,14 +60,8 @@ class CategoryPresetController implements CategoryPresetsApi {
         return ResponseEntity.ok(CategoryPresetDtoMapper.toDto(preset));
     }
 
-    @Operation(
-            summary = "Create a category preset",
-            description = "Creates a new category preset. Requires EVENTS:MANAGE authority."
-    )
-    @ApiResponse(responseCode = "201", description = "Category preset created")
     @Override
     public ResponseEntity<Void> createCategoryPreset(
-            @Parameter(description = "Preset creation data")
             CreateCategoryPresetRequest request) {
 
         CategoryPreset.CreateCategoryPreset command = new CategoryPreset.CreateCategoryPreset(request.name(), request.categories());
@@ -96,29 +72,19 @@ class CategoryPresetController implements CategoryPresetsApi {
                 .build();
     }
 
-    @Operation(
-            summary = "Update a category preset",
-            description = "Updates an existing category preset. Requires EVENTS:MANAGE authority."
-    )
-    @ApiResponse(responseCode = "204", description = "Category preset updated")
     @Override
     public ResponseEntity<Void> updateCategoryPreset(
-            @Parameter(description = "Preset UUID") @PathVariable UUID id,
-            @Parameter(description = "Preset update data") UpdateCategoryPresetRequest request) {
+            @PathVariable UUID id,
+            UpdateCategoryPresetRequest request) {
 
         CategoryPreset.UpdateCategoryPreset command = new CategoryPreset.UpdateCategoryPreset(request.name(), request.categories());
         categoryPresetManagementService.updatePreset(new CategoryPresetId(id), command);
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(
-            summary = "Delete a category preset",
-            description = "Deletes a category preset. Requires EVENTS:MANAGE authority."
-    )
-    @ApiResponse(responseCode = "204", description = "Category preset deleted")
     @Override
     public ResponseEntity<Void> deleteCategoryPreset(
-            @Parameter(description = "Preset UUID") @PathVariable UUID id) {
+            @PathVariable UUID id) {
 
         categoryPresetManagementService.deletePreset(new CategoryPresetId(id));
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/com/klabis/events/infrastructure/restapi/EventController.java
+++ b/backend/src/main/java/com/klabis/events/infrastructure/restapi/EventController.java
@@ -22,11 +22,6 @@ import com.klabis.events.domain.EventRegistration;
 import com.klabis.events.domain.EventStatus;
 import com.klabis.members.*;
 import com.klabis.members.infrastructure.restapi.MembersApi;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
@@ -65,10 +60,8 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
  */
 @RestController
 @RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)
-@Tag(name = "Events", description = "Event management API")
 @PrimaryAdapter
 @ExposesResourceFor(Event.class)
-@SecurityRequirement(name = "KlabisAuth", scopes = {Authority.EVENTS_SCOPE})
 public class EventController implements EventsApi {
 
     private final EventManagementPort eventManagementService;
@@ -90,14 +83,8 @@ public class EventController implements EventsApi {
         this.csvRenderer = csvRenderer;
     }
 
-    @Operation(
-            summary = "Create a new event",
-            description = "Creates a new event in DRAFT status. Returns Location header pointing to the created resource."
-    )
-    @ApiResponse(responseCode = "201", description = "Event successfully created")
     @Override
     public ResponseEntity<Void> createEvent(
-            @Parameter(description = "Event creation data")
             CreateEventRequest request) {
 
         Event.CreateEvent command = CreateEventRequestMapper.toCommand(request);
@@ -108,15 +95,10 @@ public class EventController implements EventsApi {
                 .build();
     }
 
-    @Operation(
-            summary = "Update an event",
-            description = "Updates event information. Only allowed for DRAFT and ACTIVE events. Any subset of fields may be provided; absent fields are left unchanged."
-    )
-    @ApiResponse(responseCode = "204", description = "Event successfully updated")
     @Override
     public ResponseEntity<Void> updateEvent(
-            @Parameter(description = "Event UUID") @PathVariable UUID id,
-            @Parameter(description = "Event update data") UpdateEventRequest request) {
+            @PathVariable UUID id,
+            UpdateEventRequest request) {
 
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         EventId eventId = new EventId(id);
@@ -131,15 +113,9 @@ public class EventController implements EventsApi {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(
-            summary = "Get event by ID",
-            description = "Retrieves detailed event information by ID. " +
-                          "Returns HATEOAS links based on event status and includes embedded registrations."
-    )
-    @ApiResponse(responseCode = "200", description = "Event found")
     @Override
     public ResponseEntity<EventDto> getEvent(
-            @Parameter(description = "Event UUID") @PathVariable UUID id,
+            @PathVariable UUID id,
             @ActingUser CurrentUserData currentUser) {
 
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
@@ -158,39 +134,18 @@ public class EventController implements EventsApi {
         return RegistrationDtoMapper.toDtoList(registrations, members, event);
     }
 
-    @Operation(
-            summary = "List events with pagination and filtering",
-            description = """
-                    Retrieves a paginated list of events.
-                    Supports filtering by status and sorting by various fields.
-                    Default: page=0, size=10, sort=eventDate,desc.
-                    Allowed sort fields: id, name, eventDate, location, organizer, status, registrationDeadline.
-                    """
-    )
-    @ApiResponse(responseCode = "200", description = "Paginated list of events retrieved successfully")
     @Override
     public ResponseEntity<Page<EventSummaryDto>> listEvents(
-            @Parameter(description = "Filter by event status (optional)")
             EventStatus status,
-            @Parameter(description = "Fulltext search on event name and location (optional)")
             String q,
-            @Parameter(description = "Filter by organizer code (optional)")
             String organizer,
-            @Parameter(description = "Filter by coordinator member UUID (optional)")
             UUID coordinator,
-            @Parameter(description = "Filter by registration: only 'me' is currently accepted (optional)")
             String registeredBy,
-            @Parameter(description = "Filter events from this date (inclusive, yyyy-MM-dd, optional)")
             LocalDate dateFrom,
-            @Parameter(description = "Filter events up to this date (inclusive, yyyy-MM-dd, optional)")
             LocalDate dateTo,
-            @Parameter(description = "Return events whose nearest future registration deadline falls within [today, today+period] (ISO-8601 duration, e.g. P7D, optional)")
             String deadlineWithin,
-            @Parameter(description = "Exclude events where the given member is registered: only 'me' is currently accepted (optional)")
             String notRegisteredBy,
-            @Parameter(description = "Filter by event type UUID (multi-value: ?eventTypeId=x&eventTypeId=y, optional)")
             List<UUID> eventTypeId,
-            @Parameter(description = "Pagination parameters: page, size, sort")
             @PageableDefault(size = 10, sort = "eventDate", direction = Sort.Direction.DESC) @ParameterObject Pageable pageable,
             @ActingUser CurrentUserData currentUser) {
 
@@ -309,28 +264,17 @@ public class EventController implements EventsApi {
         }
     }
 
-    @Operation(
-            summary = "Publish an event",
-            description = "Transitions event from DRAFT to ACTIVE status."
-    )
-    @ApiResponse(responseCode = "204", description = "Event published successfully")
     @Override
     public ResponseEntity<Void> publishEvent(
-            @Parameter(description = "Event UUID") @PathVariable UUID id) {
+            @PathVariable UUID id) {
 
         eventManagementService.publishEvent(new EventId(id));
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(
-            summary = "Cancel an event",
-            description = "Transitions event to CANCELLED status. An optional cancellation reason may be provided."
-    )
-    @ApiResponse(responseCode = "204", description = "Event cancelled successfully")
     @Override
     public ResponseEntity<Void> cancelEvent(
-            @Parameter(description = "Event UUID") @PathVariable UUID id,
-            @Parameter(description = "Optional cancellation details")
+            @PathVariable UUID id,
             CancelEventRequest request) {
 
         Event.CancelEvent command = request != null
@@ -340,16 +284,6 @@ public class EventController implements EventsApi {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(
-            summary = "Get accommodation list for an event",
-            description = """
-                    Returns the accommodation list for an event with personal details for each registered member.
-                    Accessible only to the event coordinator or users with EVENTS:REGISTRATIONS authority.
-                    Fields that are not recorded for a member are returned as null.
-                    """
-    )
-    @ApiResponse(responseCode = "200", description = "Accommodation list retrieved successfully")
-    @ApiResponse(responseCode = "403", description = "Forbidden - must be the event coordinator or have EVENTS:REGISTRATIONS")
     // Narrows the interface's inherited produces (which lists text/csv too, for documentation
     // purposes — see events.yaml) down to the HAL variant only. Without this, Spring sees two
     // handler methods both willing to serve text/csv (this one via the inherited mapping, plus
@@ -358,7 +292,7 @@ public class EventController implements EventsApi {
     @GetMapping(value = EventsApi.PATH_GET_ACCOMMODATION_LIST, produces = {MediaTypes.HAL_FORMS_JSON_VALUE, "application/problem+json"})
     @Override
     public ResponseEntity<Collection<AccommodationListItemDto>> getAccommodationList(
-            @Parameter(description = "Event UUID") @PathVariable UUID eventId) {
+            @PathVariable UUID eventId) {
 
         Event event = loadAuthorizedEventForAccommodation(eventId);
         List<AccommodationListItemDto> items = assembleAccommodationItems(event);
@@ -368,17 +302,8 @@ public class EventController implements EventsApi {
     }
 
     @GetMapping(value = "/api/events/{eventId}/accommodation-list", produces = "text/csv")
-    @Operation(
-            summary = "Download accommodation list for an event as CSV",
-            description = """
-                    Returns the accommodation list as a CSV file (UTF-8 BOM, semicolon delimiter, Czech headers).
-                    Accessible only to the event coordinator or users with EVENTS:REGISTRATIONS authority.
-                    """
-    )
-    @ApiResponse(responseCode = "200", description = "CSV file downloaded successfully")
-    @ApiResponse(responseCode = "403", description = "Forbidden - must be the event coordinator or have EVENTS:REGISTRATIONS")
     public ResponseEntity<byte[]> getAccommodationListAsCsv(
-            @Parameter(description = "Event UUID") @PathVariable UUID eventId) {
+            @PathVariable UUID eventId) {
 
         Event event = loadAuthorizedEventForAccommodation(eventId);
         List<AccommodationListItemDto> items = assembleAccommodationItems(event);

--- a/backend/src/main/java/com/klabis/events/infrastructure/restapi/EventRegistrationController.java
+++ b/backend/src/main/java/com/klabis/events/infrastructure/restapi/EventRegistrationController.java
@@ -16,11 +16,6 @@ import com.klabis.members.ActingMember;
 import com.klabis.members.MemberDto;
 import com.klabis.members.MemberId;
 import com.klabis.members.Members;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
@@ -55,10 +50,8 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @RestController
 @RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)
-@Tag(name = "EventRegistrations", description = "Event registration API for members")
 @PrimaryAdapter
 @ExposesResourceFor(EventRegistration.class)
-@SecurityRequirement(name = "KlabisAuth", scopes = {Authority.EVENTS_SCOPE})
 class EventRegistrationController implements EventRegistrationsApi {
 
     private final EventManagementPort eventManagementService;
@@ -73,17 +66,10 @@ class EventRegistrationController implements EventRegistrationsApi {
         this.entityLinks = entityLinks;
     }
 
-    @Operation(
-            summary = "Register for an event",
-            description = "Register the authenticated member for an event with SI card number. " +
-                          "Only allowed for ACTIVE events. Returns Location header pointing to the registration."
-    )
-    @ApiResponse(responseCode = "201", description = "Successfully registered for event")
-    @ApiResponse(responseCode = "409", description = "User already registered to this event")
     @Override
     public ResponseEntity<Void> registerForEvent(
-            @Parameter(description = "Event UUID") @PathVariable UUID eventId,
-            @Parameter(description = "Registration data") RegisterEventRequest request,
+            @PathVariable UUID eventId,
+            RegisterEventRequest request,
             @ActingMember MemberId actingMember) {
 
         Event.RegisterCommand command = new Event.RegisterCommand(
@@ -96,35 +82,19 @@ class EventRegistrationController implements EventRegistrationsApi {
         ).build();
     }
 
-    @Operation(
-            summary = "Unregister from an event",
-            description = """
-                    Unregister the authenticated member from an event.
-                    Only allowed before the event date.
-                    """
-    )
-    @ApiResponse(responseCode = "204", description = "Successfully unregistered")
     @Override
     public ResponseEntity<Void> unregisterFromEvent(
-            @Parameter(description = "Event UUID") @PathVariable UUID eventId,
+            @PathVariable UUID eventId,
             @ActingMember MemberId actingMember) {
 
         registrationService.unregisterMember(new EventId(eventId), actingMember);
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(
-            summary = "Edit event registration",
-            description = "Update SI card number and/or category for a member's registration. " +
-                          "Accessible by the member themselves or a user with EVENTS:REGISTRATIONS authority. " +
-                          "Only allowed when registrations are open."
-    )
-    @ApiResponse(responseCode = "204", description = "Registration updated successfully")
-    @ApiResponse(responseCode = "403", description = "Forbidden - must be the member or have EVENTS:REGISTRATIONS")
     @Override
     public ResponseEntity<Void> editRegistration(
-            @Parameter(description = "Event UUID") @PathVariable UUID eventId,
-            @Parameter(description = "Member UUID") @PathVariable UUID memberId,
+            @PathVariable UUID eventId,
+            @PathVariable UUID memberId,
             EditRegistrationRequest request) {
 
         Event.EditRegistrationCommand command = new Event.EditRegistrationCommand(
@@ -136,22 +106,9 @@ class EventRegistrationController implements EventRegistrationsApi {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(
-            summary = "List event registrations",
-            description = """
-                    List all registrations for an event.
-                    SI card numbers are not included for privacy protection.
-                    Supported sort fields: firstName, lastName, category, registrationTime.
-                    Default sort: registrationTime ASC.
-                    sort=registrationTime is silently ignored for members without EVENTS:REGISTRATIONS authority
-                    who are not the event coordinator. Unknown sort fields also fall back to default.
-                    """
-    )
-    @ApiResponse(responseCode = "200", description = "List of registrations retrieved successfully")
     @Override
     public ResponseEntity<Collection<RegistrationSummaryDto>> listRegistrations(
-            @Parameter(description = "Event UUID") @PathVariable UUID eventId,
-            @Parameter(description = "Sort field and optional direction, e.g. 'lastName' or 'lastName,desc'")
+            @PathVariable UUID eventId,
             @RequestParam(required = false) String sort) {
 
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
@@ -173,20 +130,10 @@ class EventRegistrationController implements EventRegistrationsApi {
         return ResponseEntity.ok(payload);
     }
 
-    @Operation(
-            summary = "Get registration by member ID",
-            description = "Get a member's event registration including SI card number. " +
-                          "Accessible by the member themselves or a user with EVENTS:REGISTRATIONS authority. " +
-                          "When new=true, returns prefilled defaults (siCardNumber from profile) for a not-yet-existing registration."
-    )
-    @ApiResponse(responseCode = "200", description = "Registration retrieved successfully or defaults returned (new=true)")
-    @ApiResponse(responseCode = "403", description = "Forbidden - must be the member or have EVENTS:REGISTRATIONS; or new=true with mismatched memberId")
-    @ApiResponse(responseCode = "404", description = "Member not registered for this event (new=false only)")
     @Override
     public ResponseEntity<RegistrationDto> getRegistration(
-            @Parameter(description = "Member UUID") @PathVariable UUID memberId,
-            @Parameter(description = "Event UUID") @PathVariable UUID eventId,
-            @Parameter(description = "When true, returns default prefilled registration data instead of looking up an existing registration")
+            @PathVariable UUID memberId,
+            @PathVariable UUID eventId,
             @RequestParam(required = false, defaultValue = "false") Boolean newRegistration) {
 
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();

--- a/backend/src/main/java/com/klabis/events/infrastructure/restapi/EventTypeController.java
+++ b/backend/src/main/java/com/klabis/events/infrastructure/restapi/EventTypeController.java
@@ -9,11 +9,6 @@ import com.klabis.common.users.Authority;
 import com.klabis.events.EventTypeId;
 import com.klabis.events.application.EventTypeManagementPort;
 import com.klabis.events.domain.EventType;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.hateoas.CollectionModel;
@@ -41,10 +36,8 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @RestController
 @RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)
-@Tag(name = "EventTypes", description = "Event type catalog management API")
 @PrimaryAdapter
 @ExposesResourceFor(EventType.class)
-@SecurityRequirement(name = "KlabisAuth", scopes = {Authority.EVENTS_SCOPE})
 public class EventTypeController implements EventTypesApi {
 
     private final EventTypeManagementPort eventTypeManagementService;
@@ -53,8 +46,6 @@ public class EventTypeController implements EventTypesApi {
         this.eventTypeManagementService = eventTypeManagementService;
     }
 
-    @Operation(summary = "List all event types", description = "Returns all event types sorted by sort_order. Requires EVENTS:READ authority.")
-    @ApiResponse(responseCode = "200", description = "List of event types")
     @Override
     public ResponseEntity<Collection<EventTypeDto>> listEventTypes() {
         List<EventType> eventTypes = eventTypeManagementService.listAllSorted();
@@ -67,11 +58,9 @@ public class EventTypeController implements EventTypesApi {
         return ResponseEntity.ok(payload);
     }
 
-    @Operation(summary = "Get event type by ID", description = "Returns a single event type. Requires EVENTS:READ authority.")
-    @ApiResponse(responseCode = "200", description = "Event type found")
     @Override
     public ResponseEntity<EventTypeDto> getEventType(
-            @Parameter(description = "Event type UUID") @PathVariable UUID id) {
+            @PathVariable UUID id) {
 
         EventType eventType = eventTypeManagementService.getEventType(new EventTypeId(id));
 
@@ -79,11 +68,9 @@ public class EventTypeController implements EventTypesApi {
         return ResponseEntity.ok(EventTypeDtoMapper.toDto(eventType));
     }
 
-    @Operation(summary = "Create an event type", description = "Creates a new event type. Requires EVENTS:MANAGE authority.")
-    @ApiResponse(responseCode = "201", description = "Event type created")
     @Override
     public ResponseEntity<Void> createEventType(
-            @Parameter(description = "Event type creation data") CreateEventTypeRequest request) {
+            CreateEventTypeRequest request) {
 
         EventType created = eventTypeManagementService.createEventType(EventTypeRequestMapper.toCommand(request));
         return ResponseEntity
@@ -91,22 +78,18 @@ public class EventTypeController implements EventTypesApi {
                 .build();
     }
 
-    @Operation(summary = "Update an event type", description = "Updates an existing event type. Requires EVENTS:MANAGE authority.")
-    @ApiResponse(responseCode = "204", description = "Event type updated")
     @Override
     public ResponseEntity<Void> updateEventType(
-            @Parameter(description = "Event type UUID") @PathVariable UUID id,
-            @Parameter(description = "Event type update data") UpdateEventTypeRequest request) {
+            @PathVariable UUID id,
+            UpdateEventTypeRequest request) {
 
         eventTypeManagementService.updateEventType(new EventTypeId(id), EventTypeRequestMapper.toCommand(request));
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "Delete an event type", description = "Deletes an event type not in use. Requires EVENTS:MANAGE authority.")
-    @ApiResponse(responseCode = "204", description = "Event type deleted")
     @Override
     public ResponseEntity<Void> deleteEventType(
-            @Parameter(description = "Event type UUID") @PathVariable UUID id) {
+            @PathVariable UUID id) {
 
         eventTypeManagementService.deleteEventType(new EventTypeId(id));
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/com/klabis/events/infrastructure/restapi/OrisEventController.java
+++ b/backend/src/main/java/com/klabis/events/infrastructure/restapi/OrisEventController.java
@@ -1,6 +1,5 @@
 package com.klabis.events.infrastructure.restapi;
 
-import com.klabis.common.users.Authority;
 import com.klabis.common.users.HasAuthority;
 import com.klabis.events.EventId;
 import com.klabis.events.application.BulkImportResult;
@@ -10,11 +9,6 @@ import com.klabis.events.application.OrisEventBulkImportPort;
 import com.klabis.events.application.OrisEventImportPort;
 import com.klabis.events.domain.Event;
 import com.klabis.oris.OrisIntegrationComponent;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.ResponseEntity;
@@ -30,9 +24,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @OrisIntegrationComponent
 @RestController
 @RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)
-@Tag(name = "OrisEvents", description = "ORIS event import API")
 @PrimaryAdapter
-@SecurityRequirement(name = "KlabisAuth", scopes = {Authority.EVENTS_SCOPE})
 class OrisEventController implements OrisEventsApi {
 
     private final OrisEventImportPort orisEventImportPort;
@@ -47,14 +39,8 @@ class OrisEventController implements OrisEventsApi {
         this.orisBulkSyncPort = orisBulkSyncPort;
     }
 
-    @Operation(
-            summary = "Import event from ORIS",
-            description = "Creates a new event in DRAFT status by importing data from ORIS."
-    )
-    @ApiResponse(responseCode = "201", description = "Event imported successfully")
     @Override
     public ResponseEntity<Void> importEvent(
-            @Parameter(description = "ORIS import command with orisId")
             ImportCommand command) {
 
         Event created = orisEventImportPort.importEventFromOris(command.orisId());
@@ -64,42 +50,22 @@ class OrisEventController implements OrisEventsApi {
                 .build();
     }
 
-    @Operation(
-            summary = "Sync event from ORIS",
-            description = "Re-fetches event data from ORIS and overwrites all local fields. Only allowed for DRAFT and ACTIVE events with an orisId."
-    )
-    @ApiResponse(responseCode = "204", description = "Event synced from ORIS successfully")
     @Override
     public ResponseEntity<Void> syncEventFromOris(
-            @Parameter(description = "Event UUID") @PathVariable UUID id) {
+            @PathVariable UUID id) {
 
         orisEventImportPort.syncEventFromOris(new EventId(id));
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(
-            summary = "Bulk sync all upcoming ORIS events",
-            description = "Synchronises all DRAFT/ACTIVE events with eventDate >= today that have an ORIS ID. "
-                        + "Processes each event sequentially; partial failures are collected and returned in the summary. "
-                        + "Always returns 200 — check failureCount in the response body."
-    )
-    @ApiResponse(responseCode = "200", description = "Bulk sync completed; inspect failureCount for partial failures")
     @Override
     public ResponseEntity<BulkSyncResult> syncAllUpcomingFromOris() {
         BulkSyncResult result = orisBulkSyncPort.syncAllUpcoming();
         return ResponseEntity.ok(result);
     }
 
-    @Operation(
-            summary = "Batch import events from ORIS",
-            description = "Imports multiple ORIS events in a single request. Each event is processed independently; "
-                        + "a failure to import one event does not prevent the others from being imported. "
-                        + "Always returns 200 — check failureCount in the response body for partial failures."
-    )
-    @ApiResponse(responseCode = "200", description = "Batch import completed; inspect failureCount for partial failures")
     @Override
     public ResponseEntity<BulkImportResult> importEventsBatch(
-            @Parameter(description = "Batch import command with list of ORIS event IDs")
             ImportBatchRequest request) {
 
         BulkImportResult result = orisEventBulkImportPort.importEventsFromOris(request.orisIds());

--- a/backend/src/main/java/com/klabis/finance/infrastructure/restapi/MemberAccountController.java
+++ b/backend/src/main/java/com/klabis/finance/infrastructure/restapi/MemberAccountController.java
@@ -18,10 +18,6 @@ import com.klabis.members.ActingUser;
 import com.klabis.members.CurrentUserData;
 import com.klabis.members.MemberId;
 import com.klabis.members.infrastructure.restapi.MembersApi;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -44,7 +40,6 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @PrimaryAdapter
 @RestController
 @RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)
-@Tag(name = "Finance", description = "Member financial account API")
 class MemberAccountController implements FinanceApi {
 
     private final DepositPort depositPort;
@@ -64,13 +59,10 @@ class MemberAccountController implements FinanceApi {
         this.transactionQueryPort = transactionQueryPort;
     }
 
-    @Operation(summary = "Get a member's finance account balance",
-            description = "Returns the current balance of a member's finance account.")
-    @ApiResponse(responseCode = "200", description = "Account found")
     @Transactional(readOnly = true)
     @Override
     public ResponseEntity<MemberAccountResource> getAccount(
-            @Parameter(description = "Member UUID") UUID memberId,
+            UUID memberId,
             @ActingUser CurrentUserData currentUser) {
         MemberId id = new MemberId(memberId);
         Money balance = memberAccountRepository.findBalanceById(id)
@@ -80,18 +72,14 @@ class MemberAccountController implements FinanceApi {
         return ResponseEntity.ok(resource);
     }
 
-    @Operation(summary = "List a member's account transactions",
-            description = "Paginated, filterable transaction history for a member's finance account. "
-                          + "Supports filtering by occurred-date range and transaction type.")
-    @ApiResponse(responseCode = "200", description = "Paginated transaction history")
     @Transactional(readOnly = true)
     @Override
     public ResponseEntity<Page<TransactionResource>> listTransactions(
-            @Parameter(description = "Member UUID") UUID memberId,
-            @Parameter(description = "Only include transactions occurred on or after this date") LocalDate occurredAtFrom,
-            @Parameter(description = "Only include transactions occurred on or before this date") LocalDate occurredAtTo,
-            @Parameter(description = "Transaction type filter: DEPOSIT, CHARGE, OTHER") String type,
-            @Parameter(description = "Pagination parameters: page, size, sort") Pageable pageable,
+            UUID memberId,
+            LocalDate occurredAtFrom,
+            LocalDate occurredAtTo,
+            String type,
+            Pageable pageable,
             @ActingUser CurrentUserData currentUser) {
         MemberId id = new MemberId(memberId);
         TransactionType typeFilter = type != null ? TransactionType.valueOf(type) : null;
@@ -105,14 +93,11 @@ class MemberAccountController implements FinanceApi {
         return ResponseEntity.ok(page.map(twr -> TransactionResource.from(twr.transaction())));
     }
 
-    @Operation(summary = "Get a single account transaction",
-            description = "Returns a single transaction on a member's finance account.")
-    @ApiResponse(responseCode = "200", description = "Transaction found")
     @Transactional(readOnly = true)
     @Override
     public ResponseEntity<TransactionResource> getTransaction(
-            @Parameter(description = "Member UUID") UUID memberId,
-            @Parameter(description = "Transaction UUID") UUID txId,
+            UUID memberId,
+            UUID txId,
             @ActingUser CurrentUserData currentUser) {
         MemberId id = new MemberId(memberId);
         Transaction tx = transactionQueryPort.findTransaction(id, new TransactionId(txId));
@@ -125,12 +110,9 @@ class MemberAccountController implements FinanceApi {
         return ResponseEntity.ok(TransactionResource.from(tx));
     }
 
-    @Operation(summary = "Record a deposit on a member's account",
-            description = "Records a deposit transaction, crediting the member's account balance.")
-    @ApiResponse(responseCode = "201", description = "Deposit recorded")
     @Override
     public ResponseEntity<Void> deposit(
-            @Parameter(description = "Member UUID") UUID memberId,
+            UUID memberId,
             DepositRequest request,
             @ActingUser com.klabis.common.users.UserId currentUserId) {
         LocalDate occurredAt = request.occurredAt() != null ? request.occurredAt() : LocalDate.now();
@@ -139,12 +121,9 @@ class MemberAccountController implements FinanceApi {
         return ResponseEntity.created(buildTransactionUri(memberId, tx.getId().value())).build();
     }
 
-    @Operation(summary = "Record a charge on a member's account",
-            description = "Records a charge transaction, debiting the member's account balance.")
-    @ApiResponse(responseCode = "201", description = "Charge recorded")
     @Override
     public ResponseEntity<Void> charge(
-            @Parameter(description = "Member UUID") UUID memberId,
+            UUID memberId,
             ChargeRequest request,
             @ActingUser com.klabis.common.users.UserId currentUserId) {
         LocalDate occurredAt = request.occurredAt() != null ? request.occurredAt() : LocalDate.now();
@@ -153,14 +132,10 @@ class MemberAccountController implements FinanceApi {
         return ResponseEntity.created(buildTransactionUri(memberId, tx.getId().value())).build();
     }
 
-    @Operation(summary = "Reverse an account transaction",
-            description = "Creates a reversal transaction offsetting the original. "
-                          + "Fails with 409 when the transaction has already been reversed.")
-    @ApiResponse(responseCode = "201", description = "Reversal recorded")
     @Override
     public ResponseEntity<Void> reverse(
-            @Parameter(description = "Member UUID") UUID memberId,
-            @Parameter(description = "Transaction UUID") UUID txId,
+            UUID memberId,
+            UUID txId,
             ReverseRequest request,
             @ActingUser com.klabis.common.users.UserId currentUserId) {
         LocalDate occurredAt = request.occurredAt() != null ? request.occurredAt() : LocalDate.now();

--- a/backend/src/main/java/com/klabis/groups/familygroup/infrastructure/restapi/FamilyGroupController.java
+++ b/backend/src/main/java/com/klabis/groups/familygroup/infrastructure/restapi/FamilyGroupController.java
@@ -14,9 +14,6 @@ import com.klabis.members.ActingUser;
 import com.klabis.members.CurrentUserData;
 import com.klabis.members.MemberId;
 import com.klabis.members.infrastructure.restapi.MembersApi;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
@@ -38,8 +35,6 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @PrimaryAdapter
 @RestController
 @RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)
-@Tag(name = "FamilyGroups", description = "Family group management API")
-@SecurityRequirement(name = "KlabisAuth", scopes = {Authority.GROUPS_SCOPE})
 @ExposesResourceFor(FamilyGroup.class)
 class FamilyGroupController implements FamilyGroupsApi {
 

--- a/backend/src/main/java/com/klabis/groups/freegroup/infrastructure/restapi/FreeGroupController.java
+++ b/backend/src/main/java/com/klabis/groups/freegroup/infrastructure/restapi/FreeGroupController.java
@@ -9,7 +9,6 @@ import com.klabis.common.ui.RootModel;
 import com.klabis.groups.common.domain.GroupMembership;
 import com.klabis.groups.freegroup.domain.Invitation;
 import com.klabis.groups.freegroup.domain.InvitationId;
-import com.klabis.common.users.Authority;
 import com.klabis.groups.freegroup.FreeGroupId;
 import com.klabis.groups.freegroup.application.FreeGroupManagementPort;
 import com.klabis.groups.freegroup.domain.FreeGroup;
@@ -17,8 +16,6 @@ import org.springframework.hateoas.server.ExposesResourceFor;
 import com.klabis.members.ActingMember;
 import com.klabis.members.MemberId;
 import com.klabis.members.infrastructure.restapi.MembersApi;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
@@ -41,8 +38,6 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @PrimaryAdapter
 @RestController
 @RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)
-@Tag(name = "Groups", description = "Members group management API")
-@SecurityRequirement(name = "KlabisAuth", scopes = {Authority.GROUPS_SCOPE})
 @ExposesResourceFor(FreeGroup.class)
 class FreeGroupController implements GroupsApi {
 

--- a/backend/src/main/java/com/klabis/groups/freegroup/infrastructure/restapi/PendingInvitationsController.java
+++ b/backend/src/main/java/com/klabis/groups/freegroup/infrastructure/restapi/PendingInvitationsController.java
@@ -3,14 +3,11 @@ package com.klabis.groups.freegroup.infrastructure.restapi;
 import com.klabis.common.mvc.MvcComponent;
 import com.klabis.common.ui.HalResponseContext;
 import com.klabis.common.ui.ModelWithDomainPostprocessor;
-import com.klabis.common.users.Authority;
 import com.klabis.groups.freegroup.application.FreeGroupManagementPort;
 import com.klabis.groups.freegroup.application.PendingInvitationView;
 import com.klabis.members.ActingMember;
 import com.klabis.members.MemberId;
 import com.klabis.members.infrastructure.restapi.MembersApi;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.MediaTypes;
@@ -33,8 +30,6 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @PrimaryAdapter
 @RestController
 @RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)
-@Tag(name = "Invitations", description = "Invitation management API")
-@SecurityRequirement(name = "KlabisAuth", scopes = {Authority.GROUPS_SCOPE})
 class PendingInvitationsController implements InvitationsApi {
 
     private final FreeGroupManagementPort membersGroupManagementService;

--- a/backend/src/main/java/com/klabis/groups/traininggroup/infrastructure/restapi/TrainingGroupController.java
+++ b/backend/src/main/java/com/klabis/groups/traininggroup/infrastructure/restapi/TrainingGroupController.java
@@ -16,8 +16,6 @@ import com.klabis.members.ActingUser;
 import com.klabis.members.CurrentUserData;
 import com.klabis.members.MemberId;
 import com.klabis.members.infrastructure.restapi.MembersApi;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
@@ -40,8 +38,6 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @PrimaryAdapter
 @RestController
 @RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)
-@Tag(name = "TrainingGroups", description = "Training group management API")
-@SecurityRequirement(name = "KlabisAuth", scopes = {Authority.GROUPS_SCOPE})
 @ExposesResourceFor(TrainingGroup.class)
 class TrainingGroupController implements TrainingGroupsApi {
 

--- a/backend/src/main/java/com/klabis/members/infrastructure/restapi/MemberController.java
+++ b/backend/src/main/java/com/klabis/members/infrastructure/restapi/MemberController.java
@@ -13,11 +13,6 @@ import com.klabis.members.application.ManagementPort;
 import com.klabis.members.domain.Member;
 import com.klabis.members.domain.MemberFilter;
 import com.klabis.members.domain.MemberRepository;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springdoc.core.annotations.ParameterObject;
@@ -47,9 +42,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @PrimaryAdapter
 @RestController
 @RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)
-@Tag(name = "Members ", description = "Member registration and management API")
 @ExposesResourceFor(Member.class)
-@SecurityRequirement(name = "KlabisAuth", scopes = {Authority.MEMBERS_SCOPE})
 public class MemberController implements MembersApi {
 
     private final ManagementPort managementService;
@@ -65,18 +58,9 @@ public class MemberController implements MembersApi {
         this.memberMapper = memberMapper;
     }
 
-    @Operation(
-            summary = "Update member information (partial update)",
-            description = "Updates member information with PATCH semantics (partial update). " +
-                          "Admin (MEMBERS:MANAGE) or owner can call this endpoint. " +
-                          "Field-level authorization enforces which fields each role may submit. " +
-                          "Only provided fields are updated; null/missing fields keep existing values."
-    )
-    @ApiResponse(responseCode = "204", description = "Member updated successfully")
     @Override
     public ResponseEntity<Void> updateMember(
-            @Parameter(description = "Member UUID") @PathVariable UUID id,
-            @Parameter(description = "Partial update request - only include fields to update")
+            @PathVariable UUID id,
             UpdateMemberRequest request,
             @ActingUser CurrentUserData currentUser) {
 
@@ -93,19 +77,9 @@ public class MemberController implements MembersApi {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(
-            summary = "Resume suspended member membership",
-            description = "Resumes a suspended member's membership. " +
-                          "Requires MEMBERS:MANAGE authority (admin-only). " +
-                          "Sets active status to true and records resume timestamp and user who performed resume."
-    )
-    @ApiResponse(responseCode = "204", description = "Membership resumed successfully")
-    @ApiResponse(responseCode = "400", description = "Invalid resume request (e.g., member is already active)")
-    @ApiResponse(responseCode = "403", description = "Forbidden - user lacks MEMBERS:MANAGE authority")
-    @ApiResponse(responseCode = "404", description = "Member not found")
     @Override
     public ResponseEntity<Void> resumeMember(
-            @Parameter(description = "Member UUID") @PathVariable UUID id,
+            @PathVariable UUID id,
             @ActingUser UserId currentUserId) {
 
         var command = new Member.ResumeMembership(currentUserId);
@@ -115,21 +89,9 @@ public class MemberController implements MembersApi {
                 .build();
     }
 
-    @Operation(
-            summary = "Suspend member membership",
-            description = "Suspends a member's membership with a specified reason. " +
-                          "Requires MEMBERS:MANAGE authority (admin-only). " +
-                          "Sets active status to false and records suspension details including timestamp and user who performed suspension."
-    )
-    @ApiResponse(responseCode = "204", description = "Membership suspended successfully")
-    @ApiResponse(responseCode = "400", description = "Invalid suspension request (e.g., already suspended)")
-    @ApiResponse(responseCode = "403", description = "Forbidden - user lacks MEMBERS:MANAGE authority")
-    @ApiResponse(responseCode = "404", description = "Member not found")
-    @ApiResponse(responseCode = "409", description = "Member is the sole owner of one or more groups — designate a successor before suspension")
     @Override
     public ResponseEntity<Void> suspendMember(
-            @Parameter(description = "Member UUID") @PathVariable UUID id,
-            @Parameter(description = "Suspension request")
+            @PathVariable UUID id,
             SuspendMembershipRequest request,
             @ActingUser UserId currentUserId) {
 
@@ -158,25 +120,10 @@ public class MemberController implements MembersApi {
     }
 
     @Transactional(readOnly = true)
-    @Operation(
-            summary = "List members with pagination and sorting",
-            description = "Retrieves a paginated list of registered members with summary information (firstName, lastName, registrationNumber). " +
-                          "Supports pagination (page, size) and sorting (sort=field,direction). " +
-                          "Default: page=0, size=10, sort=lastName,asc. " +
-                          "Allowed sort fields: firstName, lastName, registrationNumber. " +
-                          "Returns HATEOAS links for navigation including pagination links (first, last, next, prev). " +
-                          "Access is restricted to active members only - terminated members will receive 403 Forbidden."
-    )
-    @ApiResponse(responseCode = "200", description = "Paginated list of members retrieved successfully")
-    @ApiResponse(responseCode = "400", description = "Invalid filter parameter value")
-    @ApiResponse(responseCode = "403", description = "Forbidden - user is not an active member")
     @Override
     public ResponseEntity<Page<MemberSummaryResponse>> listMembers(
-            @Parameter(description = "Fulltext search over firstName, lastName, registrationNumber (min 2 chars)")
             @Valid @RequestParam(required = false) String q,
-            @Parameter(description = "Status filter: ACTIVE, INACTIVE, ALL. Non-MANAGE callers are silently forced to ACTIVE.")
             @Valid @RequestParam(required = false) String status,
-            @Parameter(description = "Pagination parameters: page, size, sort")
             @PageableDefault(size = 10, sort = {"lastName", "firstName"}, direction = Sort.Direction.ASC) @ParameterObject Pageable pageable,
             @ActingUser CurrentUserData currentUser) {
 
@@ -234,15 +181,9 @@ public class MemberController implements MembersApi {
         }
     }
 
-    @Operation(
-            summary = "Get member by ID",
-            description = "Retrieves detailed member information by ID including personal information, " +
-                          "contact details, and guardian information if applicable. Returns HATEOAS links for navigation."
-    )
-    @ApiResponse(responseCode = "200", description = "Member found")
     @Override
     public ResponseEntity<MemberDetailsResponse> getMember(
-            @Parameter(description = "Member UUID") @PathVariable UUID id,
+            @PathVariable UUID id,
             @ActingUser CurrentUserData currentUser) {
 
         MemberId memberId = new MemberId(id);

--- a/backend/src/main/java/com/klabis/members/infrastructure/restapi/RegistrationController.java
+++ b/backend/src/main/java/com/klabis/members/infrastructure/restapi/RegistrationController.java
@@ -1,15 +1,9 @@
 package com.klabis.members.infrastructure.restapi;
 
-import com.klabis.common.users.Authority;
 import com.klabis.common.users.UserId;
 import com.klabis.members.ActingUser;
 import com.klabis.members.application.RegistrationPort;
 import com.klabis.members.domain.Member;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.ResponseEntity;
@@ -30,8 +24,6 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @PrimaryAdapter
 @RestController
 @RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)
-@Tag(name = "Members", description = "Member registration and management API")
-@SecurityRequirement(name = "KlabisAuth", scopes = {Authority.MEMBERS_SCOPE})
 class RegistrationController implements RegistrationApi {
 
     private final RegistrationPort registrationService;
@@ -51,15 +43,8 @@ class RegistrationController implements RegistrationApi {
      * @param currentUserId the authenticated user performing the registration
      * @return 201 Created with Location header and member resource
      */
-    @Operation(
-            summary = "Register a new member",
-            description = "Creates a new member with personal information, contact details, and optional guardian information for minors. " +
-                          "Automatically generates a unique registration number in format XXXYYSS (club code, birth year, sequence)."
-    )
-    @ApiResponse(responseCode = "201", description = "Member successfully registered")
     @Override
     public ResponseEntity<Void> registerMember(
-            @Parameter(description = "Member registration data including personal information, contacts, and optional guardian")
             RegisterMemberRequest request,
             @ActingUser UserId currentUserId) {
 

--- a/backend/src/main/java/com/klabis/membershipfees/infrastructure/restapi/FeeSelectionCampaignController.java
+++ b/backend/src/main/java/com/klabis/membershipfees/infrastructure/restapi/FeeSelectionCampaignController.java
@@ -4,7 +4,6 @@ import com.klabis.common.mvc.MvcComponent;
 import com.klabis.common.ui.HalFormsInlineOption;
 import com.klabis.common.ui.HalResponseContext;
 import com.klabis.common.ui.ModelWithDomainPostprocessor;
-import com.klabis.common.users.Authority;
 import com.klabis.membershipfees.FeeSelectionCampaignId;
 import com.klabis.membershipfees.application.CampaignStatusFilter;
 import com.klabis.membershipfees.application.FeeSelectionCampaignManagementPort;
@@ -12,10 +11,6 @@ import com.klabis.membershipfees.application.ManualCampaignClosePort;
 import com.klabis.membershipfees.application.MembershipFeeTierManagementPort;
 import com.klabis.membershipfees.domain.FeeSelectionCampaign;
 import com.klabis.membershipfees.domain.MembershipFeeGroup;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.Link;
@@ -40,8 +35,6 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @PrimaryAdapter
 @RestController
 @RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)
-@Tag(name = "FeeSelectionCampaigns", description = "Publishing fee levels for a calendar year")
-@SecurityRequirement(name = "KlabisAuth", scopes = {Authority.MEMBERS_SCOPE})
 @ExposesResourceFor(FeeSelectionCampaign.class)
 class FeeSelectionCampaignController implements FeeSelectionCampaignsApi {
 
@@ -58,7 +51,6 @@ class FeeSelectionCampaignController implements FeeSelectionCampaignsApi {
     }
 
     @Override
-    @Operation(summary = "Publish fee levels for a calendar year (requires MEMBERS:MANAGE)")
     public ResponseEntity<Void> publishYear(PublishYearRequest request) {
         FeeSelectionCampaignId id = managementPort.publishYear(MembershipFeesRequestMapper.toCommand(request));
         return ResponseEntity.created(
@@ -67,9 +59,8 @@ class FeeSelectionCampaignController implements FeeSelectionCampaignsApi {
     }
 
     @Override
-    @Operation(summary = "List fee year publications, optionally filtered by status")
     public ResponseEntity<java.util.Collection<FeeSelectionCampaignResponse>> listPublications(
-            @Parameter(description = "Filter by status: 'closed' returns only past campaigns") String status) {
+            String status) {
         CampaignStatusFilter filter = status != null ? CampaignStatusFilter.valueOf(status.toUpperCase()) : CampaignStatusFilter.ALL;
         List<FeeSelectionCampaign> publications = managementPort.listPublications(filter);
         List<FeeSelectionCampaignResponse> items = publications.stream()
@@ -86,16 +77,14 @@ class FeeSelectionCampaignController implements FeeSelectionCampaignsApi {
     }
 
     @Override
-    @Operation(summary = "Get fee year publication details")
     public ResponseEntity<FeeSelectionCampaignResponse> getPublication(
-            @Parameter(description = "Publication UUID") UUID id) {
+            UUID id) {
         FeeSelectionCampaign publication = managementPort.getPublication(new FeeSelectionCampaignId(id));
         HalResponseContext.setDomain(publication);
         return ResponseEntity.ok(FeeSelectionCampaignResponse.from(publication));
     }
 
     @Override
-    @Operation(summary = "Change voting deadline of an active campaign (requires MEMBERS:MANAGE)")
     public ResponseEntity<FeeSelectionCampaignResponse> changeDeadline(
             UUID id, ChangeDeadlineRequest request) {
         FeeSelectionCampaign updated = managementPort.changeDeadline(new FeeSelectionCampaignId(id),
@@ -105,16 +94,14 @@ class FeeSelectionCampaignController implements FeeSelectionCampaignsApi {
     }
 
     @Override
-    @Operation(summary = "Manually close a campaign — processes it immediately regardless of deadline (requires MEMBERS:MANAGE)")
-    public ResponseEntity<Void> closeCampaign(@Parameter(description = "Campaign UUID") UUID id) {
+    public ResponseEntity<Void> closeCampaign(UUID id) {
         manualCampaignClosePort.closeCampaign(new FeeSelectionCampaignId(id));
         return ResponseEntity.noContent().build();
     }
 
     @Override
-    @Operation(summary = "List published fee groups for a given year")
     public ResponseEntity<java.util.Collection<MembershipFeeGroupResponse>> listGroupsForYear(
-            @Parameter(description = "Calendar year") Integer year) {
+            Integer year) {
         List<MembershipFeeGroup> groups = managementPort.listGroupsForYear(year);
         List<MembershipFeeGroupResponse> items = groups.stream()
                 .map(MembershipFeeGroupResponse::from)

--- a/backend/src/main/java/com/klabis/membershipfees/infrastructure/restapi/MemberFeeChoiceController.java
+++ b/backend/src/main/java/com/klabis/membershipfees/infrastructure/restapi/MemberFeeChoiceController.java
@@ -3,16 +3,11 @@ package com.klabis.membershipfees.infrastructure.restapi;
 import com.klabis.common.mvc.MvcComponent;
 import com.klabis.common.ui.HalResponseContext;
 import com.klabis.common.ui.ModelWithDomainPostprocessor;
-import com.klabis.common.users.Authority;
 import com.klabis.members.ActingMember;
 import com.klabis.members.MemberId;
 import com.klabis.membershipfees.MembershipFeeGroupId;
 import com.klabis.membershipfees.MembershipFeeTierId;
 import com.klabis.membershipfees.application.MemberChoicePort;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.MediaTypes;
@@ -29,8 +24,6 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @PrimaryAdapter
 @RestController
 @RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)
-@Tag(name = "MemberFeeChoice", description = "Member fee level choice API")
-@SecurityRequirement(name = "KlabisAuth", scopes = {Authority.MEMBERS_SCOPE})
 // Authorization is owner-only, declared as x-klabis-owner-visible with no paired authority (see
 // membershipfees.yaml) and enforced on the generated interface. The actingMember parameter is
 // unused in the method bodies but must stay: it is part of the generated signature and the
@@ -44,10 +37,9 @@ class MemberFeeChoiceController implements MemberFeeChoiceApi {
     }
 
     @Override
-    @Operation(summary = "Get member's current fee level choice for a year")
     public ResponseEntity<MemberFeeChoiceResponse> getChoice(
-            @Parameter(description = "Member UUID") UUID memberId,
-            @Parameter(description = "Calendar year") Integer year,
+            UUID memberId,
+            Integer year,
             @ActingMember MemberId actingMember) {
 
         MemberId memberIdObj = new MemberId(memberId);
@@ -66,10 +58,9 @@ class MemberFeeChoiceController implements MemberFeeChoiceApi {
     }
 
     @Override
-    @Operation(summary = "Choose a fee level for a year")
     public ResponseEntity<Void> chooseTier(
-            @Parameter(description = "Member UUID") UUID memberId,
-            @Parameter(description = "Calendar year") Integer year,
+            UUID memberId,
+            Integer year,
             ChooseFeeChoiceRequest request,
             @ActingMember MemberId actingMember) {
 
@@ -82,10 +73,9 @@ class MemberFeeChoiceController implements MemberFeeChoiceApi {
     }
 
     @Override
-    @Operation(summary = "Remove fee level choice for a year")
     public ResponseEntity<Void> removeChoice(
-            @Parameter(description = "Member UUID") UUID memberId,
-            @Parameter(description = "Calendar year") Integer year,
+            UUID memberId,
+            Integer year,
             @ActingMember MemberId actingMember) {
 
         memberChoicePort.removeFeeChoice(new MemberId(memberId), year);

--- a/backend/src/main/java/com/klabis/membershipfees/infrastructure/restapi/MemberFeeSummaryController.java
+++ b/backend/src/main/java/com/klabis/membershipfees/infrastructure/restapi/MemberFeeSummaryController.java
@@ -4,15 +4,10 @@ import com.klabis.common.mvc.MvcComponent;
 import com.klabis.common.ui.HalFormsInlineOption;
 import com.klabis.common.ui.HalResponseContext;
 import com.klabis.common.ui.ModelWithDomainPostprocessor;
-import com.klabis.common.users.Authority;
 import com.klabis.members.ActingMember;
 import com.klabis.members.MemberId;
 import com.klabis.membershipfees.application.FeeSelectionCampaignManagementPort;
 import com.klabis.membershipfees.application.MemberFeeHistoryPort;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.MediaTypes;
@@ -31,8 +26,6 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @PrimaryAdapter
 @RestController
 @RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)
-@Tag(name = "MemberFeeSummary", description = "Member fee level summary and history API")
-@SecurityRequirement(name = "KlabisAuth", scopes = {Authority.MEMBERS_SCOPE})
 // Owner-only authorization, declared as x-klabis-owner-visible with no paired authority — see
 // MemberFeeChoiceController for why actingMember stays despite being unused here.
 class MemberFeeSummaryController implements MemberFeeSummaryApi {
@@ -47,10 +40,9 @@ class MemberFeeSummaryController implements MemberFeeSummaryApi {
     }
 
     @Override
-    @Operation(summary = "Get member's current fee level summary for a year")
     public ResponseEntity<MemberFeeSummaryResponse> getFeeSummary(
-            @Parameter(description = "Member UUID") UUID memberId,
-            @Parameter(description = "Calendar year") Integer year,
+            UUID memberId,
+            Integer year,
             @ActingMember MemberId actingMember) {
 
         MemberFeeHistoryPort.CurrentLevelInfo info = memberFeeHistoryPort.getCurrentLevelInfo(
@@ -75,9 +67,8 @@ class MemberFeeSummaryController implements MemberFeeSummaryApi {
     }
 
     @Override
-    @Operation(summary = "Get member's fee level assignment history")
     public ResponseEntity<MemberFeeHistoryResponse> getFeeHistory(
-            @Parameter(description = "Member UUID") UUID memberId,
+            UUID memberId,
             @ActingMember MemberId actingMember) {
 
         MemberFeeHistoryResponse response = MemberFeeHistoryResponse.from(

--- a/backend/src/main/java/com/klabis/membershipfees/infrastructure/restapi/MembershipFeeGroupController.java
+++ b/backend/src/main/java/com/klabis/membershipfees/infrastructure/restapi/MembershipFeeGroupController.java
@@ -3,7 +3,6 @@ package com.klabis.membershipfees.infrastructure.restapi;
 import com.klabis.common.mvc.MvcComponent;
 import com.klabis.common.ui.HalResponseContext;
 import com.klabis.common.ui.ModelWithDomainPostprocessor;
-import com.klabis.common.users.Authority;
 import com.klabis.members.ActingMember;
 import com.klabis.members.MemberDto;
 import com.klabis.members.MemberId;
@@ -14,10 +13,6 @@ import com.klabis.membershipfees.application.FeeSelectionCampaignManagementPort;
 import com.klabis.membershipfees.domain.FeeGroupMembership;
 import com.klabis.membershipfees.domain.MembershipFeeGroup;
 import com.klabis.membershipfees.domain.PublishedLevelStatus;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.MediaTypes;
@@ -38,8 +33,6 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @PrimaryAdapter
 @RestController
 @RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)
-@Tag(name = "MembershipFeeGroups", description = "Published fee level group details API")
-@SecurityRequirement(name = "KlabisAuth", scopes = {Authority.MEMBERS_SCOPE})
 @ExposesResourceFor(MembershipFeeGroup.class)
 class MembershipFeeGroupController implements MembershipFeeGroupsApi {
 
@@ -56,9 +49,8 @@ class MembershipFeeGroupController implements MembershipFeeGroupsApi {
     }
 
     @Override
-    @Operation(summary = "Get membership fee group details with snapshot and member count")
     public ResponseEntity<MembershipFeeGroupResponse> getFeeGroup(
-            @Parameter(description = "Group UUID") UUID id) {
+            UUID id) {
         MembershipFeeGroup group = managementPort.getGroup(new MembershipFeeGroupId(id));
 
         // The members collection is declared here, not in the postprocessor: it needs the Members
@@ -83,18 +75,16 @@ class MembershipFeeGroupController implements MembershipFeeGroupsApi {
     }
 
     @Override
-    @Operation(summary = "Edit yearly fee and payment rules of a published level (requires MEMBERS:MANAGE, only while EDITABLE)")
     public ResponseEntity<Void> editSnapshot(
-            @Parameter(description = "Group UUID") UUID id,
+            UUID id,
             EditGroupSnapshotRequest request) {
         managementPort.editGroupSnapshot(new MembershipFeeGroupId(id), MembershipFeesRequestMapper.toCommand(request));
         return ResponseEntity.noContent().build();
     }
 
     @Override
-    @Operation(summary = "List payment rules snapshot for a membership fee group")
     public ResponseEntity<java.util.Collection<MembershipFeeTierResponse.PaymentRuleResponse>> listGroupRules(
-            @Parameter(description = "Group UUID") UUID id) {
+            UUID id) {
         MembershipFeeGroup group = managementPort.getGroup(new MembershipFeeGroupId(id));
         List<MembershipFeeTierResponse.PaymentRuleResponse> items = group.getRulesSnapshot().stream()
                 .map(MembershipFeeTierResponse.PaymentRuleResponse::from)
@@ -103,9 +93,8 @@ class MembershipFeeGroupController implements MembershipFeeGroupsApi {
     }
 
     @Override
-    @Operation(summary = "Assign a member to a fee group (admin emergency assignment, requires MEMBERS:MANAGE)")
     public ResponseEntity<Void> assignMember(
-            @Parameter(description = "Fee group UUID") UUID groupId,
+            UUID groupId,
             AdminAssignMemberRequest request,
             @ActingMember MemberId actingAdmin) {
 

--- a/backend/src/main/java/com/klabis/membershipfees/infrastructure/restapi/MembershipFeeTierController.java
+++ b/backend/src/main/java/com/klabis/membershipfees/infrastructure/restapi/MembershipFeeTierController.java
@@ -13,10 +13,6 @@ import com.klabis.membershipfees.application.FeeSelectionCampaignManagementPort;
 import com.klabis.membershipfees.application.MembershipFeeTierManagementPort;
 import com.klabis.membershipfees.application.RankingOptionsPort;
 import com.klabis.membershipfees.domain.*;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.Link;
@@ -41,8 +37,6 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @PrimaryAdapter
 @RestController
 @RequestMapping(produces = MediaTypes.HAL_FORMS_JSON_VALUE)
-@Tag(name = "MembershipFeeTiers", description = "Membership fee tier catalog management API")
-@SecurityRequirement(name = "KlabisAuth", scopes = {Authority.MEMBERS_SCOPE})
 @ExposesResourceFor(MembershipFeeTier.class)
 class MembershipFeeTierController implements MembershipFeeTiersApi {
 
@@ -62,7 +56,6 @@ class MembershipFeeTierController implements MembershipFeeTiersApi {
     }
 
     @Override
-    @Operation(summary = "Create a membership fee tier (requires MEMBERS:MANAGE)")
     public ResponseEntity<Void> createTier(CreateMembershipFeeTierRequest request) {
         MembershipFeeTierManagementPort.CreateTierCommand command = MembershipFeesRequestMapper.toCommand(request);
         MembershipFeeTierId id = managementPort.createTier(command);
@@ -72,7 +65,6 @@ class MembershipFeeTierController implements MembershipFeeTiersApi {
     }
 
     @Override
-    @Operation(summary = "List all membership fee tiers")
     public ResponseEntity<java.util.Collection<MembershipFeeTierSummaryResponse>> listTiers() {
         List<MembershipFeeTier> tiers = managementPort.listTiers();
         List<MembershipFeeTierSummaryResponse> items = tiers.stream()
@@ -97,18 +89,16 @@ class MembershipFeeTierController implements MembershipFeeTiersApi {
     }
 
     @Override
-    @Operation(summary = "Get membership fee tier details")
     public ResponseEntity<MembershipFeeTierResponse> getTier(
-            @Parameter(description = "Tier UUID") UUID id) {
+            UUID id) {
         MembershipFeeTier tier = managementPort.getTier(new MembershipFeeTierId(id));
         HalResponseContext.setDomain(tier);
         return ResponseEntity.ok(MembershipFeeTierResponse.from(tier));
     }
 
     @Override
-    @Operation(summary = "Edit a membership fee tier (requires MEMBERS:MANAGE)")
     public ResponseEntity<Void> editTier(
-            @Parameter(description = "Tier UUID") UUID id,
+            UUID id,
             EditMembershipFeeTierRequest request) {
         MembershipFeeTierManagementPort.EditTierCommand command = MembershipFeesRequestMapper.toCommand(request);
         managementPort.editTier(new MembershipFeeTierId(id), command);
@@ -116,9 +106,8 @@ class MembershipFeeTierController implements MembershipFeeTiersApi {
     }
 
     @Override
-    @Operation(summary = "List payment rules for a membership fee tier")
     public ResponseEntity<java.util.Collection<MembershipFeeTierResponse.PaymentRuleResponse>> listRules(
-            @Parameter(description = "Tier UUID") UUID id) {
+            UUID id) {
         MembershipFeeTier tier = managementPort.getTier(new MembershipFeeTierId(id));
         List<PaymentRuleDomain> domains = tier.getRules().stream()
                 .map(rule -> new PaymentRuleDomain(new MembershipFeeTierId(id), rule))
@@ -134,11 +123,10 @@ class MembershipFeeTierController implements MembershipFeeTiersApi {
     }
 
     @Override
-    @Operation(summary = "Get a payment rule detail from a membership fee tier")
     public ResponseEntity<MembershipFeeTierResponse.PaymentRuleResponse> getRule(
-            @Parameter(description = "Tier UUID") UUID id,
-            @Parameter(description = "Event type UUID") UUID eventTypeId,
-            @Parameter(description = "Ranking short name") String ranking) {
+            UUID id,
+            UUID eventTypeId,
+            String ranking) {
         MembershipFeeTier tier = managementPort.getTier(new MembershipFeeTierId(id));
         MembershipPaymentRule rule = tier.getRules().stream()
                 .filter(r -> r.eventTypeId().value().equals(eventTypeId) && r.rankingShortName().equals(ranking))
@@ -152,9 +140,8 @@ class MembershipFeeTierController implements MembershipFeeTiersApi {
     }
 
     @Override
-    @Operation(summary = "Add a payment rule to a membership fee tier (requires MEMBERS:MANAGE)")
     public ResponseEntity<Void> addRule(
-            @Parameter(description = "Tier UUID") UUID id,
+            UUID id,
             AddPaymentRuleRequest request) {
         MembershipFeeTierManagementPort.AddRuleCommand command = new MembershipFeeTierManagementPort.AddRuleCommand(
                 MembershipFeesRequestMapper.toDomain(request));
@@ -167,11 +154,10 @@ class MembershipFeeTierController implements MembershipFeeTiersApi {
     }
 
     @Override
-    @Operation(summary = "Edit a payment rule's value on a membership fee tier (requires MEMBERS:MANAGE)")
     public ResponseEntity<Void> editRule(
-            @Parameter(description = "Tier UUID") UUID id,
-            @Parameter(description = "Event type UUID") UUID eventTypeId,
-            @Parameter(description = "Ranking short name") String ranking,
+            UUID id,
+            UUID eventTypeId,
+            String ranking,
             EditPaymentRuleRequest request) {
         MembershipFeeTierManagementPort.EditRuleCommand command = new MembershipFeeTierManagementPort.EditRuleCommand(
                 EventTypeReference.of(eventTypeId),
@@ -183,11 +169,10 @@ class MembershipFeeTierController implements MembershipFeeTiersApi {
     }
 
     @Override
-    @Operation(summary = "Remove a payment rule from a membership fee tier (requires MEMBERS:MANAGE)")
     public ResponseEntity<Void> removeRule(
-            @Parameter(description = "Tier UUID") UUID id,
-            @Parameter(description = "Event type UUID") UUID eventTypeId,
-            @Parameter(description = "Ranking short name") String ranking) {
+            UUID id,
+            UUID eventTypeId,
+            String ranking) {
         MembershipFeeTierManagementPort.RemoveRuleCommand command = new MembershipFeeTierManagementPort.RemoveRuleCommand(
                 EventTypeReference.of(eventTypeId),
                 ranking
@@ -197,9 +182,8 @@ class MembershipFeeTierController implements MembershipFeeTiersApi {
     }
 
     @Override
-    @Operation(summary = "Delete a membership fee tier (requires MEMBERS:MANAGE)")
     public ResponseEntity<Void> deleteTier(
-            @Parameter(description = "Tier UUID") UUID id) {
+            UUID id) {
         managementPort.deleteTier(new MembershipFeeTierId(id));
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/klabis/oris/OrisController.java
+++ b/backend/src/main/java/com/klabis/oris/OrisController.java
@@ -3,11 +3,7 @@ package com.klabis.oris;
 import com.dpolach.api.orisclient.OrisApiClient;
 import com.dpolach.api.orisclient.OrisEventListFilter;
 import com.dpolach.api.orisclient.OrisRegion;
-import com.klabis.common.users.Authority;
 import com.klabis.events.application.ImportedOrisEventsPort;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jmolecules.architecture.hexagonal.PrimaryAdapter;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -27,8 +23,6 @@ import java.util.stream.Stream;
 @RestController
 @PrimaryAdapter
 @RequestMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-@Tag(name = "OrisImport", description = "ORIS orienteering system integration API")
-@SecurityRequirement(name = "KlabisAuth", scopes = {Authority.EVENTS_SCOPE})
 public class OrisController implements OrisImportApi {
 
     private final OrisApiClient orisApiClient;
@@ -40,10 +34,6 @@ public class OrisController implements OrisImportApi {
     }
 
     @Override
-    @Operation(
-            summary = "List upcoming ORIS events",
-            description = "Returns events from ORIS available for import. Accepts multiple region parameters (OrisRegion enum names) to combine results."
-    )
     public ResponseEntity<List<OrisEventSummary>> listOrisEvents(List<String> region) {
         List<OrisRegion> regions = (region == null || region.isEmpty())
                 ? List.of(OrisRegion.JIHOMORAVSKA)

--- a/docs/openapi/klabis-full.json
+++ b/docs/openapi/klabis-full.json
@@ -553,6 +553,32 @@
     ],
     "type": "object"
    },
+   "AffectedGroup": {
+    "properties": {
+     "groupId": {
+      "format": "uuid",
+      "type": "string"
+     },
+     "groupName": {
+      "type": "string"
+     },
+     "groupType": {
+      "description": "Which of the three group aggregates the member owns",
+      "enum": [
+       "FREE",
+       "FAMILY",
+       "TRAINING"
+      ],
+      "type": "string"
+     }
+    },
+    "required": [
+     "groupId",
+     "groupName",
+     "groupType"
+    ],
+    "type": "object"
+   },
    "AgeRangeRequest": {
     "properties": {
      "maxAge": {
@@ -2817,6 +2843,25 @@
     ],
     "type": "object"
    },
+   "LastOwnerWarning": {
+    "description": "The member is the sole owner of the listed groups. Each one needs another owner (or must be\ndissolved) before the suspension can go through.\n",
+    "properties": {
+     "affectedGroups": {
+      "items": {
+       "$ref": "#/components/schemas/AffectedGroup"
+      },
+      "type": "array"
+     },
+     "message": {
+      "type": "string"
+     }
+    },
+    "required": [
+     "message",
+     "affectedGroups"
+    ],
+    "type": "object"
+   },
    "Link": {
     "properties": {
      "deprecation": {
@@ -3237,6 +3282,23 @@
     },
     "type": "object"
    },
+   "MonetaryAmount": {
+    "properties": {
+     "amount": {
+      "description": "Negative when the member is in debt",
+      "type": "number"
+     },
+     "currency": {
+      "description": "ISO 4217 code",
+      "type": "string"
+     }
+    },
+    "required": [
+     "amount",
+     "currency"
+    ],
+    "type": "object"
+   },
    "OrisEventSummary": {
     "description": "A single ORIS event available for import.",
     "properties": {
@@ -3260,6 +3322,24 @@
       "type": "string"
      }
     },
+    "type": "object"
+   },
+   "OutstandingDebtWarning": {
+    "description": "The member owes money — settle the account before suspending them.",
+    "properties": {
+     "accountLink": {
+      "description": "Absolute URL of the member's finance account",
+      "format": "uri",
+      "type": "string"
+     },
+     "balance": {
+      "$ref": "#/components/schemas/MonetaryAmount"
+     }
+    },
+    "required": [
+     "balance",
+     "accountLink"
+    ],
     "type": "object"
    },
    "PageMetadata": {
@@ -3770,6 +3850,16 @@
      "reason"
     ],
     "type": "object"
+   },
+   "SuspensionBlockedWarning": {
+    "oneOf": [
+     {
+      "$ref": "#/components/schemas/OutstandingDebtWarning"
+     },
+     {
+      "$ref": "#/components/schemas/LastOwnerWarning"
+     }
+    ]
    },
    "TokenRequestRequest": {
     "properties": {
@@ -9071,6 +9161,7 @@
   },
   "/api/members/{id}/resume": {
    "post": {
+    "description": "Reactivates a suspended membership. Refused when the membership is already active.\n",
     "operationId": "resumeMember",
     "parameters": [
      {
@@ -9123,7 +9214,7 @@
   },
   "/api/members/{id}/suspend": {
    "post": {
-    "description": "Suspends an active membership. Refused when the member still has outstanding debt on their\nfinance account.\n",
+    "description": "Suspends an active membership. Refused when the member still has outstanding debt on their\nfinance account, or when they are the sole owner of at least one group — a successor must\nbe designated first.\n",
     "operationId": "suspendMember",
     "parameters": [
      {
@@ -9161,7 +9252,14 @@
       "$ref": "#/components/responses/NotFound"
      },
      "409": {
-      "$ref": "#/components/responses/Conflict"
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/SuspensionBlockedWarning"
+        }
+       }
+      },
+      "description": "Suspension is blocked — either the member owes money on their finance account, or they\nare the sole owner of at least one group.\n"
      },
      "422": {
       "$ref": "#/components/responses/UnprocessableEntity"

--- a/docs/openapi/spec/README.md
+++ b/docs/openapi/spec/README.md
@@ -14,7 +14,10 @@ docs/openapi/spec/  ──openapiBundle──▶  docs/openapi/klabis-full.json 
 - `docs/openapi/spec/` — hand-written spec; edit here
 - `docs/openapi/klabis-full.json` — committed bundle, generated; never hand-edit
 - `docs/openapi/generated/klabis-codefirst.json` — springdoc dump of what the running app serves
-  (gitignored). Nothing depends on it; it exists only for ad-hoc comparison against the spec.
+  (gitignored). Nothing depends on it; it exists only for ad-hoc comparison against the spec. Since
+  the generator runs with `documentationProvider=springdoc`, the annotations springdoc introspects
+  are themselves generated from the spec, so the two documents now differ only in the Actuator paths
+  springdoc auto-discovers.
 
 **Change an endpoint by editing the spec, not the Java.** A generated DTO or `*Api` interface edited
 by hand is overwritten on the next build.

--- a/docs/openapi/spec/members.yaml
+++ b/docs/openapi/spec/members.yaml
@@ -276,7 +276,8 @@ paths:
       summary: Suspend a membership
       description: |
         Suspends an active membership. Refused when the member still has outstanding debt on their
-        finance account.
+        finance account, or when they are the sole owner of at least one group — a successor must
+        be designated first.
       security:
         - KlabisAuth: [MEMBERS]
       x-klabis-authority: MEMBERS_MANAGE
@@ -305,7 +306,19 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
         '409':
-          $ref: '#/components/responses/Conflict'
+          # MembersExceptionHandler answers both suspension blockers with a bespoke JSON body
+          # carrying the data the caller needs to resolve them, not with a ProblemDetail — hence
+          # the local response instead of the shared #/components/responses/Conflict.
+          description: |
+            Suspension is blocked — either the member owes money on their finance account, or they
+            are the sole owner of at least one group.
+          content:
+            # application/json, not the hal-forms/problem+json this operation otherwise produces:
+            # the body comes from a @RestControllerAdvice handler returning a plain record, which
+            # is not bound by the handler method's own produces list.
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuspensionBlockedWarning'
         '422':
           $ref: '#/components/responses/UnprocessableEntity'
 
@@ -314,6 +327,8 @@ paths:
       operationId: resumeMember
       tags: [Members]
       summary: Resume a suspended membership
+      description: |
+        Reactivates a suspended membership. Refused when the membership is already active.
       security:
         - KlabisAuth: [MEMBERS]
       x-klabis-authority: MEMBERS_MANAGE
@@ -762,6 +777,66 @@ components:
         note:
           type: string
           maxLength: 500
+
+    # The 409 body of suspendMember, one of two shapes — see the schemaMapping in
+    # backend/build.gradle.kts for why it is mapped away rather than generated. Named rather than
+    # left inline: an inline oneOf makes the generator synthesise a `SuspendMember409Response`
+    # type and import it into MembersApi, and there would be no schema name to map that onto.
+    SuspensionBlockedWarning:
+      oneOf:
+        - $ref: '#/components/schemas/OutstandingDebtWarning'
+        - $ref: '#/components/schemas/LastOwnerWarning'
+
+    OutstandingDebtWarning:
+      type: object
+      description: The member owes money — settle the account before suspending them.
+      required: [balance, accountLink]
+      properties:
+        balance:
+          $ref: '#/components/schemas/MonetaryAmount'
+        accountLink:
+          type: string
+          format: uri
+          description: Absolute URL of the member's finance account
+
+    LastOwnerWarning:
+      type: object
+      description: |
+        The member is the sole owner of the listed groups. Each one needs another owner (or must be
+        dissolved) before the suspension can go through.
+      required: [message, affectedGroups]
+      properties:
+        message:
+          type: string
+        affectedGroups:
+          type: array
+          items:
+            $ref: '#/components/schemas/AffectedGroup'
+
+    AffectedGroup:
+      type: object
+      required: [groupId, groupName, groupType]
+      properties:
+        groupId:
+          type: string
+          format: uuid
+        groupName:
+          type: string
+        groupType:
+          type: string
+          enum: [FREE, FAMILY, TRAINING]
+          description: Which of the three group aggregates the member owns
+
+    MonetaryAmount:
+      type: object
+      required: [amount, currency]
+      properties:
+        amount:
+          type: number
+          description: Negative when the member is in debt
+        currency:
+          type: string
+          description: ISO 4217 code
 
     # --- Shared value objects ----------------------------------------------
 

--- a/frontend/src/api/klabisApi.d.ts
+++ b/frontend/src/api/klabisApi.d.ts
@@ -1183,7 +1183,11 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Resume a suspended membership */
+        /**
+         * Resume a suspended membership
+         * @description Reactivates a suspended membership. Refused when the membership is already active.
+         *
+         */
         post: operations["resumeMember"];
         delete?: never;
         options?: never;
@@ -1203,7 +1207,8 @@ export interface paths {
         /**
          * Suspend a membership
          * @description Suspends an active membership. Refused when the member still has outstanding debt on their
-         *     finance account.
+         *     finance account, or when they are the sole owner of at least one group — a successor must
+         *     be designated first.
          *
          */
         post: operations["suspendMember"];
@@ -1839,6 +1844,16 @@ export interface components {
             memberId: string;
             /** Format: int32 */
             year: number;
+        };
+        AffectedGroup: {
+            /** Format: uuid */
+            groupId: string;
+            groupName: string;
+            /**
+             * @description Which of the three group aggregates the member owns
+             * @enum {string}
+             */
+            groupType: "FREE" | "FAMILY" | "TRAINING";
         };
         AgeRangeRequest: {
             /** Format: int32 */
@@ -2540,6 +2555,13 @@ export interface components {
             /** Format: uuid */
             memberId: string;
         };
+        /** @description The member is the sole owner of the listed groups. Each one needs another owner (or must be
+         *     dissolved) before the suspension can go through.
+         *      */
+        LastOwnerWarning: {
+            affectedGroups: components["schemas"]["AffectedGroup"][];
+            message: string;
+        };
         Link: {
             deprecation?: string;
             href: string;
@@ -2712,6 +2734,12 @@ export interface components {
             yearlyFeeAmount?: number;
             yearlyFeeCurrency?: string;
         };
+        MonetaryAmount: {
+            /** @description Negative when the member is in debt */
+            amount: number;
+            /** @description ISO 4217 code */
+            currency: string;
+        };
         /** @description A single ORIS event available for import. */
         OrisEventSummary: {
             /** Format: date */
@@ -2721,6 +2749,15 @@ export interface components {
             location?: string | null;
             name?: string;
             organizer?: string | null;
+        };
+        /** @description The member owes money — settle the account before suspending them. */
+        OutstandingDebtWarning: {
+            /**
+             * Format: uri
+             * @description Absolute URL of the member's finance account
+             */
+            accountLink: string;
+            balance: components["schemas"]["MonetaryAmount"];
         };
         PageMetadata: {
             /** Format: int64 */
@@ -2929,6 +2966,7 @@ export interface components {
             note?: string;
             reason: components["schemas"]["DeactivationReason"];
         };
+        SuspensionBlockedWarning: components["schemas"]["OutstandingDebtWarning"] | components["schemas"]["LastOwnerWarning"];
         TokenRequestRequest: {
             /** Format: email */
             email: string;
@@ -5548,7 +5586,17 @@ export interface operations {
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
-            409: components["responses"]["Conflict"];
+            /** @description Suspension is blocked — either the member owes money on their finance account, or they
+             *     are the sole owner of at least one group.
+             *      */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SuspensionBlockedWarning"];
+                };
+            };
             422: components["responses"]["UnprocessableEntity"];
         };
     };


### PR DESCRIPTION
Preparation for deleting the springdoc annotations from the controller implementations: before removing them, audit what they actually say against the bundled spec, and migrate anything that exists only in Java.

## What the audit found

Compared all 77 `@Operation`, 85 `@ApiResponse` and 107 `@Parameter` annotations across the 26 controllers implementing a generated `*Api` against `docs/openapi/klabis-full.json`.

Almost everything is already in the spec, usually stated better. Three things were not:

**1. `suspendMember`'s 409 was wrong, not just thinner.** `MembersExceptionHandler` answers both suspension blockers with a bespoke JSON record — `LastOwnerWarning` (which groups still need another owner) or `OutstandingDebtWarning` (balance plus a link to the account). The spec pointed at the shared `Conflict` response, which promises `application/problem+json` and a `ProblemDetail`. A client generated from that would have mis-parsed every blocked suspension. Now modelled as a named `oneOf`, verified against `MemberControllerApiTest.shouldReturn409*`.

**2. `resumeMember` had no `description`.**

**3. `suspendMember`'s description** mentioned only the debt blocker, not the sole-group-owner one.

## What deliberately was not migrated

- **`(requires MEMBERS:MANAGE)` / `Requires EVENTS:READ authority`** — 16 operations. Already carried structurally by `x-klabis-authority`, which generates `@HasAuthority`. Restating it in prose is redundant and drifts.
- **Parameter descriptions** — all 42 spec parameters have one, and no `@PathVariable`/`@RequestParam`/`@RequestHeader` in any controller is missing from the spec. The 107 Java annotations include `Pageable` and request bodies, which are not `parameters` in OpenAPI.
- **`getAccommodationListAsCsv`** — has no `operationId` in the spec because the CSV output is modelled as a `text/csv` content variant of `getAccommodationList`, which is the better shape.
- **Per-operation restatements of generic error codes** (`"Member not found"` vs the shared `"Resource not found"`) — no information added.

## Generator note

`SuspensionBlockedWarning` is mapped to `java.lang.Object` in `build.gradle.kts`. The generator imports every schema a response references regardless of the `models` allow-list, so without the mapping `MembersApi` gets a dangling import. The real types are package-private nested records of the hand-written exception handler, so there is nothing to map onto. Response-only — `suspendMember` still generates as `ResponseEntity<Void>`.

## Verification

- `./gradlew openapiBundle` — 111 operations, unchanged
- `./gradlew compileJava` — clean; generated `suspendMember` signature unchanged
- `./gradlew test --tests "*MemberControllerApiTest*" --tests "*PatchRequestWrapperArchitectureTest*"` — pass
- `npm run openapi && npm run build` — pass; frontend type diff is purely additive (it now has types for the 409 bodies it previously could not describe)
- Code review by `developer:code-reviewer`, which independently re-verified the mapping is load-bearing and the JSON shapes match the handler. No blocking findings; the two actionable suggestions (enum for `groupType`, trimmed comment) are applied.


---

## Second commit: generate the annotations instead of deleting them

The audit above was preparation for deleting the springdoc annotations from the 26 controllers. It turned out there is a better option than deleting them and accepting a degraded Swagger UI.

**The whole thing hinged on one config line:** `"documentationProvider" to "none"`. Nothing subtler was going on — no custom annotation stood in for the springdoc ones, no custom `api.mustache` existed (only `pojo.mustache`/`model.mustache` are forked), and the seven `*OpenApiConfig` classes are `SpringDocUtils.replaceWithClass` domain-ID→UUID mappings, unrelated to documentation text.

Flipping it to `"springdoc"` makes the generator emit the annotations onto the `*Api` interface from the spec. **Springdoc does resolve them through the interface** — the override inherits the declaration that carries them. The skill text claiming otherwise ("springdoc scans the concrete class, and Java does not inherit method annotations from an interface") was never tested, and is what justified 616 lines of hand-written documentation that could only drift.

### Measured, not assumed

Generated `/v3/api-docs` before and after:

| | before | after |
|---|---|---|
| operations | 117 | 117 (none lost, none gained) |
| with `summary` | 82 | **117** |
| with `description` | 51 | **111** |
| parameter descriptions | 95 | **133** |
| lost response descriptions | — | **0** |

The generated set also carries `security`, `tags`, `@Content` schemas and `@Parameter(hidden = true)` on the `x-spring-provide-args` arguments — none of which the hand-written ones had.

Two apparent losses are springdoc **inaccuracies the spec corrects**:
- a bogus `200: "OK"` on `ResponseEntity<Void>` endpoints, now the real `201`/`204`
- a `410` springdoc attached to *every* operation of `PasswordSetupController` because it sat on an `@ExceptionHandler` — including `requestNewPasswordSetupToken`, which throws `TokenValidationException` and can never return 410

### The blocker, and why the fix looks the way it does

`documentationProvider` renders each response's baseType into `@Schema(implementation = <baseType>.class)`, and 16 envelope `schemaMappings` target generic types. `java.util.Collection<X>.class` is not legal Java (JLS 15.8.2: a class literal takes a raw type) — 27 occurrences across 5 modules. There is no generator hook: stock `api.mustache` emits `{{{baseType}}}` verbatim, Mustache cannot transform a string, and a lambda would mean subclassing `SpringCodegen`.

`openApiModule` therefore post-processes the generated `*Api.java`. **Which part to remove was not obvious, and the first two attempts silently made the document worse** — the operation-level metrics above stay green while response *schemas* degrade:

| approach | degraded response schemas |
|---|---|
| erase to raw type (`Page.class`) | 39 — `PageMemberSummaryResponse` → `Page`, `Collection<X>` → `{"type": "string"}` |
| drop `schema = @Schema(...)` | 39 — everything becomes `{}` |
| **drop the whole `content = {...}`** | **6** |

Springdoc falls back to the method's return type — which still carries the type argument — but only for an `@ApiResponse` declaring *no* content at all. Anything left behind wins over the fallback.

The 6 remaining are `oneOf: [ProblemDetail, ProblemDetail]` on `accommodation-list`, a degenerate union of identical branches produced because two handler methods share that path (HAL and CSV). Semantically identical to the single `$ref`.

The regex is registered via `inputs.property` because a `doLast` body is **not** part of a task's cache fingerprint and `GenerateTask` is `@CacheableTask` — without it, a cached output could be restored having been patched by an older version of the rule.

### Docs corrected

`klabis-api-spec` and `backend-patterns` both instructed the opposite ("controllers keep their springdoc annotations", and a "do not strip these" entry in the pitfalls list). Both now say the annotations are generated and must not be hand-written.

### Verification

- full backend test suite — **3200 tests, 0 failures, 0 errors**, 14 skipped
- compilation clean, including from an empty `build/`
- forced `--rerun-tasks` regeneration confirmed the post-processing runs and the cached output is correctly patched
- `npm run build` passes
- code review by `developer:code-reviewer`; its unused-import findings are applied (6 of the 18 it flagged were already dead at HEAD and were left alone), and its `PasswordSetupController` 410 finding was checked and is not a defect — see above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAsjrEgsny8rxTyPLq3sBB
